### PR TITLE
Use hassio python base image

### DIFF
--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -5,9 +5,6 @@ ENV LANG C.UTF-8
 
 MAINTAINER pbkhrv@pm.me
 
-# Install necessary packages
-RUN apk add --no-cache python3 git
-
 # Install latest pip
 RUN python3 -m ensurepip && \
     pip3 install --no-cache --upgrade pip
@@ -17,13 +14,8 @@ RUN pip3 install --no-cache paho-mqtt
 
 # Clone rtl_433 repo and copy the latest tested version of the mqtt bridge script
 # (latest as of 12/25/2020)
-RUN mkdir /tmp/build && \
-    cd /tmp/build && \
-    git clone https://github.com/pbkhrv/rtl_433 && \
-    cd rtl_433 && \
-    git checkout 29c04d8b412eb09f4cd1db4b363050d2d72e9065 && \
-    cp examples/rtl_433_mqtt_hass.py /rtl_433_mqtt_hass.py && \
-    rm -rf /tmp/build
+RUN curl -LO https://github.com/pbkhrv/rtl_433/raw/29c04d8b412eb09f4cd1db4b363050d2d72e9065/examples/rtl_433_mqtt_hass.py && \
+  chmod +x /rtl_433_mqtt_hass.py
 
 # Run script
 COPY run.sh /

--- a/rtl_433_mqtt_autodiscovery/build.json
+++ b/rtl_433_mqtt_autodiscovery/build.json
@@ -1,0 +1,9 @@
+{
+  "build_from": {
+    "aarch64": "homeassistant/aarch64-base-python:3.9-alpine3.13",
+    "amd64": "homeassistant/amd64-base-python:3.9-alpine3.13",
+    "armhf": "homeassistant/armhf-base-python:3.9-alpine3.13",
+    "armv7": "homeassistant/armv7-base-python:3.9-alpine3.13",
+    "i386": "homeassistant/i386-base-python:3.9-alpine3.13"
+  }
+}


### PR DESCRIPTION
Home Assistant builds base images with python that are recommended for addons, as it makes it much more likely there will be shared layers between multiple addons needing python: https://github.com/home-assistant/docker-base#python-images

While the final built image is larger than the current one, we can see that the actual steps far less space:

```
$ docker history 1b2e70f88a27
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
1b2e70f88a27   3 minutes ago   CMD ["/run.sh"]                                 0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN /bin/ash -o pipefail -c chmod a+x /run.s…   642B      buildkit.dockerfile.v0
<missing>      3 minutes ago   COPY run.sh / # buildkit                        642B      buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN /bin/ash -o pipefail -c mkdir /tmp/build…   18.7kB    buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN /bin/ash -o pipefail -c pip3 install --n…   417kB     buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN /bin/ash -o pipefail -c python3 -m ensur…   12.9MB    buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN /bin/ash -o pipefail -c apk add --no-cac…   53.7MB    buildkit.dockerfile.v0
<missing>      3 minutes ago   MAINTAINER pbkhrv@pm.me                         0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   ENV LANG=C.UTF-8                                0B        buildkit.dockerfile.v0

$ docker history b2bf81e25ee1
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
b2bf81e25ee1   5 minutes ago   CMD ["/run.sh"]                                 0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   RUN /bin/ash -o pipefail -c chmod a+x /run.s…   642B      buildkit.dockerfile.v0
<missing>      5 minutes ago   COPY run.sh / # buildkit                        642B      buildkit.dockerfile.v0
<missing>      5 minutes ago   RUN /bin/ash -o pipefail -c curl -LO https:/…   18.7kB    buildkit.dockerfile.v0
<missing>      8 minutes ago   RUN /bin/ash -o pipefail -c pip3 install --n…   407kB     buildkit.dockerfile.v0
<missing>      8 minutes ago   RUN /bin/ash -o pipefail -c python3 -m ensur…   8.69MB    buildkit.dockerfile.v0
<missing>      8 minutes ago   MAINTAINER pbkhrv@pm.me                         0B        buildkit.dockerfile.v0
<missing>      8 minutes ago   ENV LANG=C.UTF-8                                0B        buildkit.dockerfile.v0
```

This switches to using that as a base image, as well as uses curl instead of git to get the forked version of the mqtt discovery script.