### PR TITLE
Support multiple templated configuration files for multiple radios

### DIFF
--- a/rtl_433/README.md
+++ b/rtl_433/README.md
@@ -36,17 +36,17 @@ Once you get the rtl_433 sensor data into MQTT, you'll need to help Home Assista
 
  3. Install the add-on.
 
- 4. Configure the add-on
-
-  * Set the `rtl_433_conf_file` key to match the path to the config file you uploaded in step 2 (without the "/config" in the beginning, so if you saved your file to `/config/rtl_433/rtl_433.conf`, then specify only `rtl_433/rtl_433.conf` part).
-
  5. Plug your SDR dongle to the machine running the add-on.
+
+ 5. Start the addon. A default configuration will be created in `/config/rtl_433/`. To add or edit additional configurations, create multiple `.conf.template` files in that directory.
 
  6. Start the add-on and check the logs.
 
 ## Configuration
 
-First, take a look at the example config file included in the rtl_433 source code: [rtl_433.example.conf](https://github.com/merbanan/rtl_433/blob/master/conf/rtl_433.example.conf)
+For a "zero configuration" setup, install the [Mosquitto broker](https://github.com/home-assistant/addons/blob/master/mosquitto/DOCS.md) addon. While other brokers may work, they are not tested and will require manual setup. Once the addon is installed, start or restart the rtl_433 and rtl_433_mqtt_autodiscovery addons to start capturing known 433 MHz protocols.
+
+For more advanced configuration, take a look at the example config file included in the rtl_433 source code: [rtl_433.example.conf](https://github.com/merbanan/rtl_433/blob/master/conf/rtl_433.example.conf)
 
 Assuming that you intend to get the rtl_433 data into Home Assistant, the absolute minimum that you need to specify in the config file is the [MQTT connection and authentication information](https://triq.org/rtl_433/OPERATION.html#mqtt-output):
 

--- a/rtl_433/README.md
+++ b/rtl_433/README.md
@@ -48,6 +48,8 @@ For a "zero configuration" setup, install the [Mosquitto broker](https://github.
 
 For more advanced configuration, take a look at the example config file included in the rtl_433 source code: [rtl_433.example.conf](https://github.com/merbanan/rtl_433/blob/master/conf/rtl_433.example.conf)
 
+The `retain` option controls if MQTT's `retain` flag is enabled or disabled by default. It can be overridden on a per-radio basis by setting `retain` to `true` or `false` in the `output` setting.
+
 Assuming that you intend to get the rtl_433 data into Home Assistant, the absolute minimum that you need to specify in the config file is the [MQTT connection and authentication information](https://triq.org/rtl_433/OPERATION.html#mqtt-output):
 
 ```

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -7,12 +7,14 @@
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "application",
   "boot": "auto",
-  "map": ["config"],
+  "map": ["config:rw"],
+  "services": ["mqtt:want"],
   "usb": true,
+  "udev": true,
   "options": {
-    "rtl_433_conf_file": "rtl_433/rtl_433.conf"
+    "retain": true
   },
   "schema": {
-    "rtl_433_conf_file": "str"
+    "retain": "bool"
   }
 }

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -12,9 +12,11 @@
   "usb": true,
   "udev": true,
   "options": {
+    "rtl_433_conf_file": "",
     "retain": true
   },
   "schema": {
+    "rtl_433_conf_file": "str?",
     "retain": "bool"
   }
 }

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -2,17 +2,12 @@
 
 conf_directory="/config/rtl_433"
 
-# See https://stackoverflow.com/a/34407620
-uriencode() {
-  jq -sRr @uri
-}
-
 if bashio::services.available "mqtt"; then
-    host=$(bashio::services "mqtt" "host" | uriencode)
-    password=$(bashio::services "mqtt" "password" | uriencode )
-    port=$(bashio::services "mqtt" "port" | uriencode)
-    username=$(bashio::services "mqtt" "username" | uriencode)
-    retain=$(bashio::config "retain" | uriencode)
+    host=$(bashio::services "mqtt" "host")
+    password=$(bashio::services "mqtt" "password")
+    port=$(bashio::services "mqtt" "port")
+    username=$(bashio::services "mqtt" "username")
+    retain=$(bashio::config "retain")
 else
     bashio::log.info "The mqtt addon is not available."
     bashio::log.info "Manually update the output line in the configuration file with mqtt connection settings, and restart the addon."

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -68,7 +68,8 @@ do
     source /tmp/rtl_433_heredoc
 
     echo "Starting rtl_433 with $live..."
-    rtl_433 -c "$live"&
+    tag=$(basename $live .conf)
+    rtl_433 -c "$live" > >(sed "s/^/[$tag] /") 2> >(>&2 sed "s/^/[$tag] /")&
     rtl_433_pids+=($!)
 done
 

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -18,6 +18,19 @@ then
     mkdir -p $conf_directory
 fi
 
+# Check if the legacy configuration file is set and alert that it's deprecated.
+conf_file=$(bashio::config "rtl_433_conf_file")
+
+if [[ $conf_file != "" ]]
+then
+    bashio::log.warning "rtl_433 now supports automatic configuration and multiple radios. The rtl_433_conf_file option is deprecated. See the documentation for migration instructions."
+    conf_file="/config/$conf_file"
+
+    echo "Starting rtl_433 -c $conf_file"
+    rtl_433 -c "$conf_file"
+    exit $?
+fi
+
 # Create a reasonable default configuration in /config/rtl_433.
 if [ ! "$(ls -A $conf_directory)" ]
 then

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -2,12 +2,17 @@
 
 conf_directory="/config/rtl_433"
 
+# See https://stackoverflow.com/a/34407620
+uriencode() {
+  jq -sRr @uri
+}
+
 if bashio::services.available "mqtt"; then
-    host=$(bashio::services "mqtt" "host")
-    password=$(bashio::services "mqtt" "password")
-    port=$(bashio::services "mqtt" "port")
-    username=$(bashio::services "mqtt" "username")
-    retain=$(bashio::config "retain")
+    host=$(bashio::services "mqtt" "host" | uriencode)
+    password=$(bashio::services "mqtt" "password" | uriencode )
+    port=$(bashio::services "mqtt" "port" | uriencode)
+    username=$(bashio::services "mqtt" "username" | uriencode)
+    retain=$(bashio::config "retain" | uriencode)
 else
     bashio::log.info "The mqtt addon is not available."
     bashio::log.info "Manually update the output line in the configuration file with mqtt connection settings, and restart the addon."

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -1,7 +1,62 @@
 #!/usr/bin/env bashio
 
-CONF_FILE=$(bashio::config "rtl_433_conf_file")
-CONF_FILE="/config/$CONF_FILE"
+conf_directory="/config/rtl_433"
 
-echo "Starting rtl_433 -c $CONF_FILE"
-rtl_433 -c "$CONF_FILE"
+if bashio::services.available "mqtt"; then
+    host=$(bashio::services "mqtt" "host")
+    password=$(bashio::services "mqtt" "password")
+    port=$(bashio::services "mqtt" "port")
+    username=$(bashio::services "mqtt" "username")
+    retain=$(bashio::config "retain")
+else
+    bashio::log.info "The mqtt addon is not available."
+    bashio::log.info "Manually update the output line in the configuration file with mqtt connection settings, and restart the addon."
+fi
+
+if [ ! -d $conf_directory ]
+then
+    mkdir -p $conf_directory
+fi
+
+# Create a reasonable default configuration in /config/rtl_433.
+if [ ! "$(ls -A $conf_directory)" ]
+then
+    cat > $conf_directory/rtl_433.conf.template <<EOD
+# This is an empty template for configuring rtl_433. mqtt information will be
+# automatically added. Create multiple files ending in '.conf.template' to
+# manage multiple rtl_433 radios, being sure to set the 'device' setting.
+# https://github.com/merbanan/rtl_433/blob/master/conf/rtl_433.example.conf
+
+output mqtt://\${host}:\${port},user=\${username},pass=\${password},retain=\${retain}
+
+# Uncomment the following line to also enable the default "table" output to the
+# addon logs.
+# output kv
+EOD
+fi
+
+# Remove all rendered configuration files.
+rm -f $conf_directory/*.conf
+
+rtl_433_pids=()
+for template in $conf_directory/*.conf.template
+do
+    # Remove '.template' from the file name.
+    live=$(echo $template | rev | cut -c 10- | rev)
+
+    # By sourcing the template, we can substitute any environment variable in
+    # the template. In fact, enterprising users could write _any_ valid bash
+    # to create the final configuration file. To simplify template creation,
+    # we wrap the needed redirections into a temparary file.
+    echo "cat <<EOD > $live" > /tmp/rtl_433_heredoc
+    cat $template >> /tmp/rtl_433_heredoc
+    echo EOD >> /tmp/rtl_433_heredoc
+
+    source /tmp/rtl_433_heredoc
+
+    echo "Starting rtl_433 with $live..."
+    rtl_433 -c "$live"&
+    rtl_433_pids+=($!)
+done
+
+wait -n ${rtl_433_pids[*]}

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -55,7 +55,7 @@ rtl_433_pids=()
 for template in $conf_directory/*.conf.template
 do
     # Remove '.template' from the file name.
-    live=$(echo $template | rev | cut -c 10- | rev)
+    live=$(basename $template .template)
 
     # By sourcing the template, we can substitute any environment variable in
     # the template. In fact, enterprising users could write _any_ valid bash


### PR DESCRIPTION
Todo:

- [x] Support the single-file approach, and document when / if it will be removed completely.
- [x] Support prepending each line with the process it's from. I have code that did this to separate out autodiscovery from rtl_433, it should be straightforward to adapt.
- [x] Confirm that `#` in passwords and other shell characters are escaped correctly
- [x] Update documentation
- [x] Figure out the notification / changelog plan as this is a hard break for existing users. I would lean towards "documentation" and not "backwards compatibility" given this isn't even in the community addons repo.
- [x] Document the "retain" option

I'm considering updating the auto-discovery addon to be a separate PR. My thinking is that we get that working first, and then follow up with upstream to see if one or two addons is preferred.