### PR TITLE
Update version for new upstream rtl_433 release (#33)

### DIFF
--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,6 +1,6 @@
 {
   "name": "rtl_433",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",


### PR DESCRIPTION
I know there's some open issues about build failures, and they may not be fixed in main. However, updating the version will at least ensure everyone testing is on the same commit, at least in the short term.