### PR TITLE
Prevent using old cached rtl_433 repository during installation or update

### DIFF
--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -13,10 +13,11 @@ RUN apk add --no-cache --virtual .buildDeps \
     git
 
 WORKDIR /build
+ARG rtl433GitRevision=21.12
 RUN git clone https://github.com/merbanan/rtl_433
 WORKDIR ./rtl_433
 
-ARG rtl433GitRevision=21.12
+
 RUN git checkout ${rtl433GitRevision}
 WORKDIR ./build
 RUN cmake ..


### PR DESCRIPTION
Fixes #41 as suggested by @deviantintegral. To recreate the issue, version v1.2 needs to be installed and then updated to v1.3.