### PR TITLE
Add an initial action for building images

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -16,6 +16,9 @@ jobs:
         service: ["rtl_433", "rtl_433_mqtt_autodiscovery"]
 
     steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
 #    -
 #      name: Set up QEMU
 #      uses: docker/setup-qemu-action@v1
@@ -36,7 +39,7 @@ jobs:
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: {{defaultContext}}:${{ matrix.service }}
+        context: ${{ matrix.service }}
         platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -18,9 +18,9 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v2
 
-     -
-       name: Set up QEMU
-       uses: docker/setup-qemu-action@v1
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
 
     -
       name: Set up Docker Buildx

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -27,6 +27,7 @@ jobs:
         args: |
           --test \
           --all \
+          --docker-hub ghcr.io/pbkhrv \
           --version $GITHUB_REF_SLUG \
           --target rtl_433
 
@@ -47,5 +48,6 @@ jobs:
         args: |
           --test \
           --all \
+          --docker-hub ghcr.io/pbkhrv \
           --version $GITHUB_REF_SLUG \
           --target rtl_433_mqtt_autodiscovery

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v2
 
-    -
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+#    -
+#      name: Set up QEMU
+#      uses: docker/setup-qemu-action@v1
 
     -
       name: Set up Docker Buildx

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -7,7 +7,7 @@ on:
     types: ["published"]
 
 jobs:
-  build_rtl433:
+  build_rtl_433:
     name: Build rtl_433 addon
     runs-on: ubuntu-latest
 
@@ -22,6 +22,7 @@ jobs:
           --all \
           --version ${{github.ref_name}} \
           --target rtl_433
+
   build_rtl_433_mqtt_autodiscovery:
     name: Build rtl_433_mqtt_autodiscovery addon
     runs-on: ubuntu-latest

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build:
     name: Build ${{ matrix.arch }} ${{ matrix.service }} addon
-    needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -41,6 +41,7 @@ jobs:
           --docker-hub ghcr.io \
           --image pbkhrv/rtl_433-hass-addons-rtl_433-{arch} \
           --version $GITHUB_REF_SLUG \
+          --no-latest \
           --target rtl_433
 
   build_rtl_433_mqtt_autodiscovery:
@@ -69,4 +70,5 @@ jobs:
           --docker-hub ghcr.io \
           --image pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch} \
           --version $GITHUB_REF_SLUG \
+          --no-latest \
           --target rtl_433_mqtt_autodiscovery

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,7 +2,6 @@ name: Build rtl_433 images
 
 on:
   push:
-    branches: ["next"]
   pull_request:
   release:
     types: ["published"]

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -28,7 +28,6 @@ jobs:
       uses: home-assistant/builder@master
       with:
         args: |
-          --test \
           --all \
           --docker-hub ghcr.io \
           --image pbkhrv/rtl_433-hass-addons-rtl_433-{arch} \
@@ -53,7 +52,6 @@ jobs:
       uses: home-assistant/builder@master
       with:
         args: |
-          --test \
           --all \
           --docker-hub ghcr.io \
           --image pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch} \

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -36,7 +36,7 @@ jobs:
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: ${{ matrix.service }}
+        context: ./${{ matrix.service }}
         platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -16,9 +16,6 @@ jobs:
         services: ["rtl_433", "rtl_433_mqtt_autodiscovery"]
 
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v2
-
 #    -
 #      name: Set up QEMU
 #      uses: docker/setup-qemu-action@v1
@@ -39,7 +36,7 @@ jobs:
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: ${{ matrix.service }}
+        context: {{defaultContext}}:${{ matrix.service }}
         platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -24,7 +24,7 @@ jobs:
         args: |
           --test \
           --all \
-          --version $GITHUB_REF_SLUG$ \
+          --version $GITHUB_REF_SLUG \
           --target rtl_433
 
   build_rtl_433_mqtt_autodiscovery:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -6,16 +6,15 @@ on:
       - next
       - main
   pull_request:
-  release:
-    types: ["published"]
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_rtl_433:
     name: Build rtl_433 addon
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
 
     steps:
     - name: Inject slug/short variables
@@ -37,9 +36,6 @@ jobs:
   build_rtl_433_mqtt_autodiscovery:
     name: Build rtl_433_mqtt_autodiscovery addon
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
 
     steps:
     - name: Inject slug/short variables

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         context: ./rtl_433_mqtt_autodiscovery
         build-args: |
-          BUILD_FROM=ghcr.io/home-assistant/${{matrix.arch}}-base-python:3.14
+          BUILD_FROM=ghcr.io/home-assistant/${{matrix.arch}}-base-python:3.9-alpine3.14
         #platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -12,15 +12,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
+
     - name: Checkout the repository
       uses: actions/checkout@v2
+
     - name: Test build
       uses: home-assistant/builder@master
       with:
         args: |
           --test \
           --all \
-          --version ${{github.ref_name}} \
+          --version $GITHUB_REF_SLUG$ \
           --target rtl_433
 
   build_rtl_433_mqtt_autodiscovery:
@@ -28,13 +32,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
+
     - name: Checkout the repository
       uses: actions/checkout@v2
+
     - name: Test build
       uses: home-assistant/builder@master
       with:
         args: |
           --test \
           --all \
-          --version ${{github.ref_name}} \
+          --version $GITHUB_REF_SLUG \
           --target rtl_433_mqtt_autodiscovery

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -36,7 +36,7 @@ jobs:
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: ./${{ matrix.service }}
+        context: {{defaultContext}}:${{ matrix.service }}
         platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # arch: ["linux/armhf", "linux/armv7", "linux/aarch64", "linux/amd64", "linux/i386"]
-        services: ["rtl_433", "rtl_433_mqtt_autodiscovery"]
+        service: ["rtl_433", "rtl_433_mqtt_autodiscovery"]
 
     steps:
 #    -
@@ -36,7 +36,7 @@ jobs:
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: {{defaultContext}}:${{ matrix.service }}
+        context: ${{ matrix.service }}
         platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -13,6 +13,9 @@ jobs:
   build_rtl_433:
     name: Build rtl_433 addon
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
     - name: Inject slug/short variables
@@ -35,6 +38,9 @@ jobs:
   build_rtl_433_mqtt_autodiscovery:
     name: Build rtl_433_mqtt_autodiscovery addon
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
     - name: Inject slug/short variables

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -18,9 +18,9 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v2
 
-#    -
-#      name: Set up QEMU
-#      uses: docker/setup-qemu-action@v1
+     -
+       name: Set up QEMU
+       uses: docker/setup-qemu-action@v1
 
     -
       name: Set up Docker Buildx

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,6 +2,9 @@ name: Build rtl_433 images
 
 on:
   push:
+    branches:
+      - next
+      - main
   pull_request:
   release:
     types: ["published"]

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -3,23 +3,40 @@ name: Build rtl_433 images
 on:
   push:
   pull_request:
+  release:
+    types: ["published"]
 
 jobs:
   build:
-    name: Build rtl_433 addon
+    name: Build ${{ matrix.arch }} ${{ matrix.service }} addon
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # arch: ["linux/armhf", "linux/armv7", "linux/aarch64", "linux/amd64", "linux/i386"]
+        service: ["rtl_433", "rtl_433_mqtt_autodiscovery"]
 
     steps:
+#    -
+#      name: Set up QEMU
+#      uses: docker/setup-qemu-action@v1
 
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
     -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    -
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: {{defaultContext}}:rtl_433
+        context: {{defaultContext}}:${{ matrix.service }}
         platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,0 +1,49 @@
+name: Build rtl_433 images
+
+on:
+  push:
+    branches: ["next"]
+  pull_request:
+    branches: ["main", "next"]
+  release:
+    types: ["published"]
+
+jobs:
+  build:
+    name: Build ${{ matrix.arch }} ${{ matrix.service }} addon
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # arch: ["linux/armhf", "linux/armv7", "linux/aarch64", "linux/amd64", "linux/i386"]
+        services: ["rtl_433", "rtl_433_mqtt_autodiscovery"]
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    -
+      name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{ matrix.service }}
+        platforms: linux/amd64,linux/arm64
+        push: false
+        tags: |
+          ghcr.io/pbkhrv/rtl_433-hass-addons:latest

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -7,53 +7,31 @@ on:
     types: ["published"]
 
 jobs:
-  build:
-    name: Build ${{ matrix.arch }} addons
+  build_rtl433:
+    name: Build rtl_433 addon
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: ["armhf", "armv7", "aarch64", "amd64", "i386"]
 
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v2
-
-    -
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-
-    -
-      name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    -
-      name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+    - name: Test build
+      uses: home-assistant/builder@master
       with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        args: |
+          --test \
+          --all \
+          --target rtl_433
+  build_rtl_433_mqtt_autodiscovery:
+    name: Build rtl_433_mqtt_autodiscovery addon
+    runs-on: ubuntu-latest
 
-    -
-      name: Build and push rtl_433
-      uses: docker/build-push-action@v2
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+    - name: Test build
+      uses: home-assistant/builder@master
       with:
-        context: ./rtl_433
-        build-args: |
-          BUILD_FROM=ghcr.io/home-assistant/${{matrix.arch}}-base:3.14
-        #platforms: linux/amd64,linux/arm64
-        push: false
-        tags: |
-          ghcr.io/pbkhrv/rtl_433-hass-addons:latest
-
-    -
-      name: Build and push rtl_433_mqtt_autodiscovery
-      uses: docker/build-push-action@v2
-      with:
-        context: ./rtl_433_mqtt_autodiscovery
-        build-args: |
-          BUILD_FROM=ghcr.io/home-assistant/${{matrix.arch}}-base-python:3.9-alpine3.14
-        #platforms: linux/amd64,linux/arm64
-        push: false
-        tags: |
-          ghcr.io/pbkhrv/rtl_433-hass-addons:latest
+        args: |
+          --test \
+          --all \
+          --target rtl_433_mqtt_autodiscovery

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -20,6 +20,7 @@ jobs:
         args: |
           --test \
           --all \
+          --version ${{github.ref_name}} \
           --target rtl_433
   build_rtl_433_mqtt_autodiscovery:
     name: Build rtl_433_mqtt_autodiscovery addon
@@ -34,4 +35,5 @@ jobs:
         args: |
           --test \
           --all \
+          --version ${{github.ref_name}} \
           --target rtl_433_mqtt_autodiscovery

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["next"]
   pull_request:
-    branches: ["main", "next"]
   release:
     types: ["published"]
 

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -39,7 +39,7 @@ jobs:
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: ${{ matrix.service }}
+        context: ./${{ matrix.service }}
         platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -27,7 +27,8 @@ jobs:
         args: |
           --test \
           --all \
-          --docker-hub ghcr.io/pbkhrv \
+          --docker-hub ghcr.io \
+          --image pbkhrv/rtl_433-hass-addons-rtl_433-{arch} \
           --version $GITHUB_REF_SLUG \
           --target rtl_433
 
@@ -48,6 +49,7 @@ jobs:
         args: |
           --test \
           --all \
-          --docker-hub ghcr.io/pbkhrv \
+          --docker-hub ghcr.io \
+          --image pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch} \
           --version $GITHUB_REF_SLUG \
           --target rtl_433_mqtt_autodiscovery

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,12 +8,11 @@ on:
 
 jobs:
   build:
-    name: Build ${{ matrix.arch }} ${{ matrix.service }} addon
+    name: Build ${{ matrix.arch }} addons
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # arch: ["linux/armhf", "linux/armv7", "linux/aarch64", "linux/amd64", "linux/i386"]
-        service: ["rtl_433", "rtl_433_mqtt_autodiscovery"]
+        arch: ["armhf", "armv7", "aarch64", "amd64", "i386"]
 
     steps:
     - name: Checkout the repository
@@ -29,18 +28,32 @@ jobs:
 
     -
       name: Login to GitHub Container Registry
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v1
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     -
-      name: Build and push
+      name: Build and push rtl_433
       uses: docker/build-push-action@v2
       with:
-        context: ./${{ matrix.service }}
-        platforms: linux/amd64,linux/arm64
+        context: ./rtl_433
+        build-args: |
+          BUILD_FROM=ghcr.io/home-assistant/${{matrix.arch}}-base:3.14
+        #platforms: linux/amd64,linux/arm64
+        push: false
+        tags: |
+          ghcr.io/pbkhrv/rtl_433-hass-addons:latest
+
+    -
+      name: Build and push rtl_433_mqtt_autodiscovery
+      uses: docker/build-push-action@v2
+      with:
+        context: ./rtl_433_mqtt_autodiscovery
+        build-args: |
+          BUILD_FROM=ghcr.io/home-assistant/${{matrix.arch}}-python:3.14
+        #platforms: linux/amd64,linux/arm64
         push: false
         tags: |
           ghcr.io/pbkhrv/rtl_433-hass-addons:latest

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+env:
+  REGISTRY: ghcr.io
+
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -3,40 +3,23 @@ name: Build rtl_433 images
 on:
   push:
   pull_request:
-  release:
-    types: ["published"]
 
 jobs:
   build:
-    name: Build ${{ matrix.arch }} ${{ matrix.service }} addon
+    name: Build rtl_433 addon
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # arch: ["linux/armhf", "linux/armv7", "linux/aarch64", "linux/amd64", "linux/i386"]
-        service: ["rtl_433", "rtl_433_mqtt_autodiscovery"]
 
     steps:
-#    -
-#      name: Set up QEMU
-#      uses: docker/setup-qemu-action@v1
 
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
     -
-      name: Login to GitHub Container Registry
-      uses: docker/login-action@v1 
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    -
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        context: {{defaultContext}}:${{ matrix.service }}
+        context: {{defaultContext}}:rtl_433
         platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -23,6 +23,13 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v2
 
+    - name: Login to Packages Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Test build
       uses: home-assistant/builder@master
       with:
@@ -43,6 +50,13 @@ jobs:
 
     - name: Checkout the repository
       uses: actions/checkout@v2
+
+    - name: Login to Packages Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Test build
       uses: home-assistant/builder@master

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         context: ./rtl_433_mqtt_autodiscovery
         build-args: |
-          BUILD_FROM=ghcr.io/home-assistant/${{matrix.arch}}-python:3.14
+          BUILD_FROM=ghcr.io/home-assistant/${{matrix.arch}}-base-python:3.14
         #platforms: linux/amd64,linux/arm64
         push: false
         tags: |

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,6 +1,6 @@
 {
   "name": "rtl_433",
-  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons/rtl_433-{arch}",
+  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-{arch}",
   "version": "0.1.3",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,5 +1,6 @@
 {
   "name": "rtl_433",
+  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons/rtl_433-{arch}",
   "version": "0.1.3",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -1,5 +1,6 @@
 {
   "name": "rtl_433 MQTT Auto Discovery",
+  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons/rtl_433_mqtt_autodiscovery-{arch}",
   "version": "0.2.1",
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -1,6 +1,6 @@
 {
   "name": "rtl_433 MQTT Auto Discovery",
-  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons/rtl_433_mqtt_autodiscovery-{arch}",
+  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch}",
   "version": "0.2.1",
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

This PR aims to build images in GitHub actions. Since this is a public repository, actions minutes and container storage are currently free.

When complete, this should allow for users to simply download prebuilt images instead of having to wait for their (potentially slow) systems to build the containers. It will also isolate users more from ephemeral network issues, since they will be dependent on the GitHub container registry and nothing else.

## Alternatives Considered

Users will be able to continue to build images locally if desired, but that has led to bugs such as when different versions of the image had different cache layers in place.

## Testing Steps

_tbd, I need to get this working first!_

1. First...
2. Then...
3. You should see... (screenshots or console text are helpful)