### PR TITLE
Update rtl_433_mqtt_hass.py

### DIFF
--- a/rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py
+++ b/rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py
@@ -284,6 +284,16 @@ mappings = {
         }
     },
 
+    "wind_max_km_h": {
+        "device_type": "sensor",
+        "object_suffix": "WS",
+        "config": {
+            "name": "Wind Speed Max",
+            "unit_of_measurement": "km/h",
+            "value_template": "{{ float(value|float) * 3.6 }}"
+        }
+    },
+
     "gust_speed_km_h": {
         "device_type": "sensor",
         "object_suffix": "GS",
@@ -324,6 +334,16 @@ mappings = {
         }
     },
 
+    "flags": {
+        "device_type": "sensor",
+        "object_suffix": "WD",
+        "config": {
+            "name": "Wind Direction",
+            "unit_of_measurement": "°",
+            "value_template": "{{ value|float }}"
+        }
+    },
+
     "rain_mm": {
         "device_type": "sensor",
         "object_suffix": "RT",
@@ -333,7 +353,17 @@ mappings = {
             "value_template": "{{ value|float }}"
         }
     },
-
+  
+    "rain": {
+        "device_type": "sensor",
+        "object_suffix": "RT",
+        "config": {
+            "name": "Rain Total",
+            "unit_of_measurement": "mm",
+            "value_template": "{{ value|float }}"
+        }
+    },
+  
     "rain_mm_h": {
         "device_type": "sensor",
         "object_suffix": "RR",


### PR DESCRIPTION
Skipped sensors of my weather station WS2032

Log:

homeassistant/sensor/WS2032-21508/WS2032-21508-UTC/config : {"device_class": "timestamp", "name": "WS2032-21508-UTC", "icon": "mdi:clock-in", "state_topic": "rtl_433/9b13b3f4-rtl433/devices/WS2032/21508/time", "unique_id": "WS2032-21508-UTC", "device": {"identifiers": "WS2032-21508", "name": "WS2032-21508", "model": "WS2032", "manufacturer": "rtl_433"}}
homeassistant/sensor/WS2032-21508/WS2032-21508-B/config : {"device_class": "battery", "name": "WS2032-21508-B", "unit_of_measurement": "%", "value_template": "{{ float(value|int) * 99 + 1 }}", "state_topic": "rtl_433/9b13b3f4-rtl433/devices/WS2032/21508/battery_ok", "unique_id": "WS2032-21508-B", "device": {"identifiers": "WS2032-21508", "name": "WS2032-21508", "model": "WS2032", "manufacturer": "rtl_433"}}
homeassistant/sensor/WS2032-21508/WS2032-21508-T/config : {"device_class": "temperature", "name": "WS2032-21508-T", "unit_of_measurement": "\u00b0C", "value_template": "{{ value|float }}", "state_topic": "rtl_433/9b13b3f4-rtl433/devices/WS2032/21508/temperature_C", "unique_id": "WS2032-21508-T", "device": {"identifiers": "WS2032-21508", "name": "WS2032-21508", "model": "WS2032", "manufacturer": "rtl_433"}}
homeassistant/sensor/WS2032-21508/WS2032-21508-H/config : {"device_class": "humidity", "name": "WS2032-21508-H", "unit_of_measurement": "%", "value_template": "{{ value|float }}", "state_topic": "rtl_433/9b13b3f4-rtl433/devices/WS2032/21508/humidity", "unique_id": "WS2032-21508-H", "device": {"identifiers": "WS2032-21508", "name": "WS2032-21508", "model": "WS2032", "manufacturer": "rtl_433"}}
homeassistant/sensor/WS2032-21508/WS2032-21508-WD/config : {"name": "WS2032-21508-WD", "unit_of_measurement": "\u00b0", "value_template": "{{ value|float }}", "state_topic": "rtl_433/9b13b3f4-rtl433/devices/WS2032/21508/wind_dir_deg", "unique_id": "WS2032-21508-WD", "device": {"identifiers": "WS2032-21508", "name": "WS2032-21508", "model": "WS2032", "manufacturer": "rtl_433"}}
homeassistant/sensor/WS2032-21508/WS2032-21508-WS/config : {"name": "WS2032-21508-WS", "unit_of_measurement": "km/h", "value_template": "{{ value|float }}", "state_topic": "rtl_433/9b13b3f4-rtl433/devices/WS2032/21508/wind_avg_km_h", "unique_id": "WS2032-21508-WS", "device": {"identifiers": "WS2032-21508", "name": "WS2032-21508", "model": "WS2032", "manufacturer": "rtl_433"}}
Published WS2032/21508: time, battery_ok, temperature_C, humidity, wind_dir_deg, wind_avg_km_h
Skipped WS2032/21508: wind_max_km_h, rain, flags

<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

<!-- Write a summary of what you're trying to solve, with links to any relevant
     issues, and how this PR solves it.
     -->

## Alternatives Considered

<!-- Are there other ways to add the feature or solve the bug you considered?
     Why didn't you pursue them further?
     -->

## Testing Steps

1. First...
2. Then...
3. You should see... (screenshots or console text are helpful)