### PR TITLE
Add workflow to build images for all architectures

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,0 +1,74 @@
+name: Build rtl_433 images
+
+on:
+  push:
+    branches:
+      - next
+      - main
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_rtl_433:
+    name: Build rtl_433 addon
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
+
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
+    - name: Login to Packages Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push rtl_433 image
+      uses: home-assistant/builder@master
+      with:
+        args: |
+          --all \
+          --docker-hub ghcr.io \
+          --image pbkhrv/rtl_433-hass-addons-rtl_433-{arch} \
+          --version $GITHUB_REF_SLUG \
+          --no-latest \
+          --target rtl_433
+
+  build_rtl_433_mqtt_autodiscovery:
+    name: Build rtl_433_mqtt_autodiscovery addon
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
+
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
+    - name: Login to Packages Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push rtl_433_mqtt_autodiscovery image
+      uses: home-assistant/builder@master
+      with:
+        args: |
+          --all \
+          --docker-hub ghcr.io \
+          --image pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch} \
+          --version $GITHUB_REF_SLUG \
+          --no-latest \
+          --target rtl_433_mqtt_autodiscovery


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

This PR replaces https://github.com/pbkhrv/rtl_433-hass-addons/pull/53 and is basically identical. The most significant difference is that we don't yet put in `image` lines to `config.json`. In other words, we'll be creating images, making sure they build correctly, and pushing them to GitHub, but they won't be consumed unless someone manually pulls the images.

Images are built for:

- Pull requests (forks have to be approved by maintainers to run the job)
- main
- next

## Alternatives Considered

We could have pushed to Docker Hub, but that would require more work without an obvious benefit.

## Testing Steps

1. See the PR build.
2. Test pulling the pushed images.
3. Test manually running the images by pulling them with Supervisor's CLI, retagging them locally, and starting the addon.
4. Test by reinstalling the addon with a local config.json change to include the image key.