### PR TITLE
Use variables for registry and repository

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -38,8 +38,8 @@ jobs:
       with:
         args: |
           --all \
-          --docker-hub ghcr.io \
-          --image pbkhrv/rtl_433-hass-addons-rtl_433-{arch} \
+          --docker-hub $REGISTRY \
+          --image ${{ github.repository}}-rtl_433-{arch} \
           --version $GITHUB_REF_SLUG \
           --no-latest \
           --target rtl_433
@@ -67,8 +67,8 @@ jobs:
       with:
         args: |
           --all \
-          --docker-hub ghcr.io \
-          --image pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch} \
+          --docker-hub $REGISTRY \
+          --image ${{ github.repository}}-rtl_433_mqtt_autodiscovery-{arch} \
           --version $GITHUB_REF_SLUG \
           --no-latest \
           --target rtl_433_mqtt_autodiscovery


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

This ensures that if the repository is forked, jobs push images to the forked repository instead of trying (and failing) to push the images here. This also fixes pushing to the organization instead of the repository (I misread the docs on how that works).

## Testing Steps

1. I tested this at https://github.com/deviantintegral/rtl_433-hass-addons/pull/1 so as long as builds here pass we should be good.