### PR TITLE
Fix pushing images from forks

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -41,7 +41,6 @@ jobs:
       if: github.event.pull_request.head.repo.full_name != github.repository
       with:
         args: |
-          --all \
           --test \
           --${{ matrix.arch }} \
           --docker-hub $REGISTRY \
@@ -55,7 +54,6 @@ jobs:
       if: github.event.pull_request.head.repo.full_name == github.repository
       with:
         args: |
-          --all \
           --${{ matrix.arch }} \
           --docker-hub $REGISTRY \
           --image ${{ github.repository}}-rtl_433-{arch} \
@@ -89,7 +87,6 @@ jobs:
       if: github.event.pull_request.head.repo.full_name != github.repository
       with:
         args: |
-          --all \
           --test \
           --${{ matrix.arch }} \
           --docker-hub $REGISTRY \
@@ -103,7 +100,6 @@ jobs:
       if: github.event.pull_request.head.repo.full_name == github.repository
       with:
         args: |
-          --all \
           --${{ matrix.arch }} \
           --docker-hub $REGISTRY \
           --image ${{ github.repository}}-rtl_433_mqtt_autodiscovery-{arch} \

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -18,6 +18,9 @@ jobs:
   build_rtl_433:
     name: Build rtl_433 addon
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [armhf, armv7, amd64, i386]
 
     steps:
     - name: Inject slug/short variables
@@ -33,11 +36,27 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push rtl_433 image
+    - name: Build rtl_433 image
       uses: home-assistant/builder@master
+      if: github.event.pull_request.head.repo.full_name != github.repository
       with:
         args: |
           --all \
+          --test \
+          --${{ matrix.arch }} \
+          --docker-hub $REGISTRY \
+          --image ${{ github.repository}}-rtl_433-{arch} \
+          --version $GITHUB_REF_SLUG \
+          --no-latest \
+          --target rtl_433
+
+    - name: Build and push rtl_433 image
+      uses: home-assistant/builder@master
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        args: |
+          --all \
+          --${{ matrix.arch }} \
           --docker-hub $REGISTRY \
           --image ${{ github.repository}}-rtl_433-{arch} \
           --version $GITHUB_REF_SLUG \
@@ -47,6 +66,9 @@ jobs:
   build_rtl_433_mqtt_autodiscovery:
     name: Build rtl_433_mqtt_autodiscovery addon
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [armhf, armv7, amd64, i386]
 
     steps:
     - name: Inject slug/short variables
@@ -62,11 +84,27 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push rtl_433_mqtt_autodiscovery image
+    - name: Build rtl_433_mqtt_autodiscovery image
       uses: home-assistant/builder@master
+      if: github.event.pull_request.head.repo.full_name != github.repository
       with:
         args: |
           --all \
+          --test \
+          --${{ matrix.arch }} \
+          --docker-hub $REGISTRY \
+          --image ${{ github.repository}}-rtl_433_mqtt_autodiscovery-{arch} \
+          --version $GITHUB_REF_SLUG \
+          --no-latest \
+          --target rtl_433_mqtt_autodiscovery
+
+    - name: Build and push rtl_433_mqtt_autodiscovery image
+      uses: home-assistant/builder@master
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        args: |
+          --all \
+          --${{ matrix.arch }} \
           --docker-hub $REGISTRY \
           --image ${{ github.repository}}-rtl_433_mqtt_autodiscovery-{arch} \
           --version $GITHUB_REF_SLUG \


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

I misunderstood how secrets in forks works for actions. While they get a token, that token may not have permission to push. I had thought I could approve the build, which is true, but it still doesn't give forks the secrets needed to push.

This PR changes CI to only _build_ and not push from forks. As well, it switches to using matrix jobs, as even after a job is complete all of the logs are jumbled together.

## Alternatives Considered

I considered using `pull_request_target` to reduce secrets restrictions, but I think the risks outweigh the gains. If a contributor really needs images pushed to the registry, we can open a new PR from a branch or the contributor can open a PR to their own fork to trigger it.

## Testing Steps

1. I'm opening this PR from my own fork. It should build, but not push.
2. I will then open the same code as a branch in the upstream repo, and it should build and push.