### PR TITLE
Roll back protocol and path changes in 1665 patch

### DIFF
--- a/rtl_433_mqtt_autodiscovery/1665.diff
+++ b/rtl_433_mqtt_autodiscovery/1665.diff
@@ -1,5 +1,5 @@
 diff --git a/examples/rtl_433_mqtt_hass.py b/examples/rtl_433_mqtt_hass.py
-index 706d9437..abfd05ad 100755
+index 706d9437..bccf3ebf 100755
 --- a/examples/rtl_433_mqtt_hass.py
 +++ b/examples/rtl_433_mqtt_hass.py
 @@ -111,7 +111,7 @@ NAMING_KEYS = [ "type", "model", "subtype", "channel", "id" ]
@@ -28,11 +28,10 @@ index 706d9437..abfd05ad 100755
      "battery_ok": {
          "device_type": "sensor",
          "object_suffix": "B",
-@@ -536,7 +544,60 @@ mappings = {
-             "state_class": "total_increasing"
+@@ -537,6 +545,61 @@ mappings = {
          }
      },
--
+ 
 +    "channel": {
 +        "device_type": "device_automation",
 +        "object_suffix": "CH",
@@ -86,38 +85,22 @@ index 706d9437..abfd05ad 100755
 +           "type": "button_short_release",
 +           "subtype": "button_1",
 +        }
-+    }
++    },
++
  }
  
  
-@@ -583,17 +644,19 @@ def sanitize(text):
- def rtl_433_device_topic(data):
-     """Return rtl_433 device topic to subscribe to for a data element"""
+@@ -592,8 +655,7 @@ def rtl_433_device_topic(data):
  
--    path_elements = []
-+    #path_elements = []
+     return '/'.join(path_elements)
  
--    for key in NAMING_KEYS:
--        if key in data:
--            element = sanitize(str(data[key]))
--            path_elements.append(element)
-+    #for key in NAMING_KEYS:
-+    #    if key in data:
-+    #        element = sanitize(str(data[key]))
-+    #        path_elements.append(element)
- 
--    return '/'.join(path_elements)
-+    uid = data.get('id')
-+    if uid is None: uid = 0
-+    return 'ID'+str(uid) # '/'.join(path_elements)
- 
- 
+-
 -def publish_config(mqttc, topic, model, instance, mapping):
 +def publish_config(mqttc, topic, model, instance, mapping, value=None):
      """Publish Home Assistant auto discovery data."""
      global discovery_timeouts
  
-@@ -615,10 +678,16 @@ def publish_config(mqttc, topic, model, instance, mapping):
+@@ -615,10 +677,16 @@ def publish_config(mqttc, topic, model, instance, mapping):
      discovery_timeouts[path] = now + args.discovery_interval
  
      config = mapping["config"].copy()
@@ -138,25 +121,3 @@ index 706d9437..abfd05ad 100755
  
      if args.force_update:
          config["force_update"] = "true"
-@@ -637,7 +706,7 @@ def bridge_event_to_hass(mqttc, topicprefix, data):
-         logging.debug("Model is not defined. Not sending event to Home Assistant.")
-         return
- 
--    model = sanitize(data["model"])
-+    model = 'P' + str(data["protocol"])
- 
-     skipped_keys = []
-     published_keys = []
-@@ -651,9 +720,9 @@ def bridge_event_to_hass(mqttc, topicprefix, data):
-     # detect known attributes
-     for key in data.keys():
-         if key in mappings:
--            # topic = "/".join([topicprefix,"devices",model,instance,key])
--            topic = "/".join([topicprefix,"devices",instance,key])
--            if publish_config(mqttc, topic, model, instance, mappings[key]):
-+            # topic = "/".join([topicprefix,model,instance,key])
-+            topic = "/".join([topicprefix,model,instance,key])
-+            if publish_config(mqttc, topic, model, instance, mappings[key], data[key]):
-                 published_keys.append(key)
-         else:
-             if key not in SKIP_KEYS:

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -9,7 +9,8 @@ COPY 1665.diff \
 
 RUN apk add patch
 RUN wget https://raw.githubusercontent.com/merbanan/rtl_433/${rtl433GitRevision}/examples/rtl_433_mqtt_hass.py -O rtl_433_mqtt_hass.py
-https://github.com/merbanan/rtl_433/pull/1665#issuecomment-1034188020
+
+# https://github.com/merbanan/rtl_433/pull/1665#issuecomment-1034188020
 RUN patch -u rtl_433_mqtt_hass.py 1665.diff
 
 FROM ${BUILD_FROM}

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -9,7 +9,7 @@ COPY 1665.diff \
 
 RUN apk add patch
 RUN wget https://raw.githubusercontent.com/merbanan/rtl_433/${rtl433GitRevision}/examples/rtl_433_mqtt_hass.py -O rtl_433_mqtt_hass.py
-# https://github.com/merbanan/rtl_433/pull/1665.diff
+https://github.com/merbanan/rtl_433/pull/1665#issuecomment-1034188020
 RUN patch -u rtl_433_mqtt_hass.py 1665.diff
 
 FROM ${BUILD_FROM}


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

Fixes the startup error as detailed at https://github.com/merbanan/rtl_433/pull/1665#issuecomment-1034168299