### PR TITLE
Recommend running the discovery addon as needed

### DIFF
--- a/rtl_433_mqtt_autodiscovery/README.md
+++ b/rtl_433_mqtt_autodiscovery/README.md
@@ -85,6 +85,8 @@ To install this Home Assistant add-on you need to add the rtl_433 add-on reposit
 
  4. Scroll down, select the "rtl_433 MQTT Auto Discovery" add-on and install it.
 
+ 5. It is only recommended to run the addon when trying to add a new device. Keep Autostart off, start the addon to register new devices, and then shut it down when done. Otherwise, `rtl_433` is likely to pick up many devices at the edge of it's range, or transient devices like tire pressure monitoring sensors (TPMS) adding many undesired devices to Home Assistant.
+
 ## Configuration
 
 By default, this addon assumes the official Mosquitto addon is installed. In that case, the MQTT connection information is determined automatically. Otherwise, to use an external broker, provide the following configuration options:

--- a/rtl_433_mqtt_autodiscovery/README.md
+++ b/rtl_433_mqtt_autodiscovery/README.md
@@ -85,7 +85,7 @@ To install this Home Assistant add-on you need to add the rtl_433 add-on reposit
 
  4. Scroll down, select the "rtl_433 MQTT Auto Discovery" add-on and install it.
 
- 5. It is only recommended to run the addon when trying to add a new device. Keep Autostart off, start the addon to register new devices, and then shut it down when done. Otherwise, `rtl_433` is likely to pick up many devices at the edge of it's range, or transient devices like tire pressure monitoring sensors (TPMS) adding many undesired devices to Home Assistant.
+ 5. It is only recommended to run the addon when trying to add a new device. Keep "Start on boot" off, start the addon to register new devices, and then shut it down when done. Otherwise, `rtl_433` is likely to pick up many devices at the edge of it's range, or transient devices like tire pressure monitoring sensors (TPMS) adding many undesired devices to Home Assistant.
 
 ## Configuration
 


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

This updates the documentation as a workaround for those who live in busy areas.

https://community.home-assistant.io/t/home-assistant-add-on-rtl-433-with-mqtt-auto-discovery/260665/159?u=deviantintegral

## Alternatives Considered

It would be neat to have a discovery UI and a way to automatically remove old devices, but this will improve most user's experience for now.