### PR TITLE
Add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+# This is nearly identical to the builds on PRs, but doesn't specify
+# `--version` to builder so each addon gets it's own version.
+name: Create new rtl_433 addon release
+
+on:
+  tags:
+    - '*'
+
+env:
+  REGISTRY: ghcr.io
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_rtl_433:
+    name: Build rtl_433 addon
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [armhf, armv7, amd64, i386]
+
+    steps:
+    - name: Make sure tag doesn't exist
+      run: |
+        set -e
+        sudo apt-get update
+        sudo apt-get install -y jq
+        TAG=$(jq '.version' < rtl_433/config.json)
+        ! docker manifest inspect ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-${{ matrix.arch }}:$TAG > /dev/null
+
+     - name: Inject slug/short variables
+       uses: rlespinasse/github-slug-action@v4
+ 
+     - name: Checkout the repository
+       uses: actions/checkout@v2
+ 
+     - name: Login to Packages Container registry
+       uses: docker/login-action@v1
+       with:
+         registry: ${{ env.REGISTRY }}
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
+ 
+     - name: Build rtl_433 image
+       uses: home-assistant/builder@master
+       if: github.event.pull_request.head.repo.full_name != github.repository
+       with:
+         args: |
+           --test \
+           --${{ matrix.arch }} \
+           --docker-hub $REGISTRY \
+           --image ${{ github.repository}}-rtl_433-{arch} \
+           --no-latest \
+           --target rtl_433
+ 
+     - name: Build and push rtl_433 image
+       uses: home-assistant/builder@master
+       if: github.event.pull_request.head.repo.full_name == github.repository
+       with:
+         args: |
+           --${{ matrix.arch }} \
+           --docker-hub $REGISTRY \
+           --image ${{ github.repository}}-rtl_433-{arch} \
+           --no-latest \
+           --target rtl_433
+ 
+   build_rtl_433_mqtt_autodiscovery:
+     name: Build rtl_433_mqtt_autodiscovery addon
+     runs-on: ubuntu-latest
+     strategy:
+       matrix:
+         arch: [armhf, armv7, amd64, i386]
+ 
+     steps:
+     - name: Inject slug/short variables
+       uses: rlespinasse/github-slug-action@v4
+ 
+     - name: Checkout the repository
+       uses: actions/checkout@v2
+ 
+     - name: Login to Packages Container registry
+       uses: docker/login-action@v1
+       with:
+         registry: ${{ env.REGISTRY }}
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
+ 
+     - name: Build rtl_433_mqtt_autodiscovery image
+       uses: home-assistant/builder@master
+       if: github.event.pull_request.head.repo.full_name != github.repository
+       with:
+         args: |
+           --test \
+           --${{ matrix.arch }} \
+           --docker-hub $REGISTRY \
+           --image ${{ github.repository}}-rtl_433_mqtt_autodiscovery-{arch} \
+           --no-latest \
+           --target rtl_433_mqtt_autodiscovery
+ 
+     - name: Build and push rtl_433_mqtt_autodiscovery image
+       uses: home-assistant/builder@master
+       if: github.event.pull_request.head.repo.full_name == github.repository
+       with:
+         args: |
+           --${{ matrix.arch }} \
+           --docker-hub $REGISTRY \
+           --image ${{ github.repository}}-rtl_433_mqtt_autodiscovery-{arch} \
+           --no-latest \
+           --target rtl_433_mqtt_autodiscovery


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

We need a separate workflow so we can specify the release versions separately for each addon.

## Testing Steps

1. Since I'm not going to tag this, we should verify that this workflow doesn't execute in the PR.