### PR TITLE
Add aarch64 builds

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [armhf, armv7, amd64, i386]
+        arch: [armhf, armv7, aarch64, amd64, i386]
 
     steps:
     - name: Inject slug/short variables
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [armhf, armv7, amd64, i386]
+        arch: [armhf, armv7, aarch64, amd64, i386]
 
     steps:
     - name: Inject slug/short variables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         set -e
         sudo apt-get update
         sudo apt-get install -y jq
+        set -x
         TAG=$(jq '.version' < rtl_433/config.json)
         ! docker manifest inspect ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-${{ matrix.arch }}:$TAG > /dev/null
 
@@ -74,6 +75,7 @@ jobs:
         set -e
         sudo apt-get update
         sudo apt-get install -y jq
+        set -x
         TAG=$(jq '.version' < rtl_433_mqtt_autodiscovery/config.json)
         ! docker manifest inspect ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-${{ matrix.arch }}:$TAG > /dev/null
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ name: Create new rtl_433 addon release
 on:
   push:
     tags:
+      - '\d\d\d\d\..*'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [armhf, armv7, amd64, i386]
+        arch: [armhf, armv7, aarch64, amd64, i386]
 
     steps:
     - name: Checkout the repository
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [armhf, armv7, amd64, i386]
+        arch: [armhf, armv7, aarch64, amd64, i386]
 
     steps:
     - name: Inject slug/short variables

--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [UNRELEASED] - 2022-02-19
+
+- Add builds for aarch64
+- **READ BEFORE UPDATING** below still applies
+
 ## [0.2.0] - 2022-02-14
 
 **READ BEFORE UPDATING**

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [UNRELEASED] - 2022-02-19
+
+- Add builds for aarch64
+- **READ BEFORE UPDATING** below still applies
+
 ## [0.3.0] - 2022-02-14
 
 **READ BEFORE UPDATING**


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

Adds missing aarch64 builds as reported at https://community.home-assistant.io/t/home-assistant-add-on-rtl-433-with-mqtt-auto-discovery/260665/171?u=deviantintegral

## Testing Steps

1. Make sure aarch64 builds in the action logs