### PR TITLE
Update to rtl_433 master as of Mar 26, 2022

### DIFF
--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=homeassistant/amd64-base-python:3.9-alpine3.13
 FROM ${BUILD_FROM} as builder
 
-ARG rtl433GitRevision=2b49b81aafee4aef6015385ee44dc7e0d9f0073d
+ARG rtl433GitRevision=778b94ca984c9792a5f5d5bee8910de6bd473b26
 
 # Copy files from root folder
 COPY 1665.diff \


### PR DESCRIPTION
## Summary

Update the Dockerfile to pull in the autodiscovery code from the latest master revision at the moment, mainly to bring over my change to enable SCM consumption data (merbanan/rtl_433#2023).

## Alternatives Considered

Forking the add-on and running my fork instead of submitting this pull request. I could do that, but I prefer to not have to manage my own add-on.

## Testing Steps

1. Check the build succeeds (GitHub Actions workflows) and the 1665.diff patch applies cleanly.