### PR TITLE
Update upstream rtl_433

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ This is a collection of Home Assistant add-ons that work with [rtl_433](https://
 * [rtl_433/config.json](rtl_433/config.json) and [rtl_433_mqtt_autodiscovery/config.json](rtl_433_mqtt_autodiscovery/config.json) will contain the version numbers of the previously set addon versions, but will have different code.
 * When `next` is ready to be tagged for a release:
   1. Create a pull request bumping the versions of each `config.json` file if the individual addon has been changed. As well, update the `CHANGELOG.md` in the same pull request.
-  2. When the pull request has been approved and merged into `next`, merge `next` into `main`. Note the new version(s) in the commit message.
-  3. Note we do not tag `main` in git, since each addon has it's own version number.
+  2. When the pull request has been approved and merged into `next`, create a date-based tag such as 2022-12-01. This will build docker containers with the version numbers in `config.json`.
+  3. Merge `next` into `main` to actually promote the release to end users. Note the new version(s) in the commit message.
+    - Note we do not tag `main` in git, since each addon has it's own version number.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a collection of Home Assistant add-ons that work with [rtl_433](https://
 * [rtl_433/config.json](rtl_433/config.json) and [rtl_433_mqtt_autodiscovery/config.json](rtl_433_mqtt_autodiscovery/config.json) will contain the version numbers of the previously set addon versions, but will have different code.
 * When `next` is ready to be tagged for a release:
   1. Create a pull request against `main`, bumping the versions of each `config.json` file if the individual addon has been changed. As well, update the `CHANGELOG.md` in the same pull request.
-  2. When the pull request has been approved, create a date-based tag such as `2022.12.01` on the last commit of the pull request. This will build docker containers with the version numbers in `config.json`.
+  2. When the pull request has been approved, create a date-based tag such as `2022.12.01.0` on the last commit of the pull request. This will build docker containers with the version numbers in `config.json`.
   3. Merge the PR into `main` to actually promote the release to end users. Note the new version(s) in the commit message.
     - Note we do not tag `main` in git, since each addon has it's own version number.
   4. Create a new branch off of `main` setting the addon versions back to `next`. Create a PR to merge `main` into `next` to reconcile the branches.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a collection of Home Assistant add-ons that work with [rtl_433](https://
 * [rtl_433/config.json](rtl_433/config.json) and [rtl_433_mqtt_autodiscovery/config.json](rtl_433_mqtt_autodiscovery/config.json) will contain the version numbers of the previously set addon versions, but will have different code.
 * When `next` is ready to be tagged for a release:
   1. Create a pull request against `main`, bumping the versions of each `config.json` file if the individual addon has been changed. As well, update the `CHANGELOG.md` in the same pull request.
-  2. When the pull request has been approved, create a date-based tag such as `2022-12-01` on the last commit of the pull request. This will build docker containers with the version numbers in `config.json`.
+  2. When the pull request has been approved, create a date-based tag such as `2022.12.01` on the last commit of the pull request. This will build docker containers with the version numbers in `config.json`.
   3. Merge the PR into `main` to actually promote the release to end users. Note the new version(s) in the commit message.
     - Note we do not tag `main` in git, since each addon has it's own version number.
   4. Create a new branch off of `main` setting the addon versions back to `next`. Create a PR to merge `main` into `next` to reconcile the branches.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This is a collection of Home Assistant add-ons that work with [rtl_433](https://
 * The [next](https://github.com/pbkhrv/rtl_433-hass-addons/tree/next) branch represents the upcoming version of these addons.
 * [rtl_433/config.json](rtl_433/config.json) and [rtl_433_mqtt_autodiscovery/config.json](rtl_433_mqtt_autodiscovery/config.json) will contain the version numbers of the previously set addon versions, but will have different code.
 * When `next` is ready to be tagged for a release:
-  1. Create a pull request bumping the versions of each `config.json` file if the individual addon has been changed. As well, update the `CHANGELOG.md` in the same pull request.
-  2. When the pull request has been approved and merged into `next`, create a date-based tag such as 2022-12-01. This will build docker containers with the version numbers in `config.json`.
-  3. Merge `next` into `main` to actually promote the release to end users. Note the new version(s) in the commit message.
+  1. Create a pull request against `main`, bumping the versions of each `config.json` file if the individual addon has been changed. As well, update the `CHANGELOG.md` in the same pull request.
+  2. When the pull request has been approved, create a date-based tag such as `2022-12-01` on the last commit of the pull request. This will build docker containers with the version numbers in `config.json`.
+  3. Merge the PR into `main` to actually promote the release to end users. Note the new version(s) in the commit message.
     - Note we do not tag `main` in git, since each addon has it's own version number.
+  4. Create a new branch off of `main` setting the addon versions back to `next`. Create a PR to merge `main` into `next` to reconcile the branches.

--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,5 +1,7 @@
-## [UNRELEASED] - YYYY-MM-DD
+## [0.2.3] - 2022-05-09
 
+- Update to rtl_433 master as of April 28, 2022.
+-
 ## [0.2.2] - 2022-04-02
 
 - Update to rtl_433 master as of Mar 26, 2022 #82

--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [UNRELEASED] - YYYY-MM-DD
+
 ## [0.2.2] - 2022-04-02
 
 - Update to rtl_433 master as of Mar 26, 2022 #82

--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache --virtual .buildDeps \
     git
 
 WORKDIR /build
-ARG rtl433GitRevision=778b94ca984c9792a5f5d5bee8910de6bd473b26
+ARG rtl433GitRevision=9eec461132ee880c4e1a969026f81be9934682cf
 RUN git clone https://github.com/merbanan/rtl_433
 WORKDIR ./rtl_433
 

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-{arch}",
-  "version": "0.2.2",
+  "version": "next",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-{arch}",
-  "version": "next",
+  "version": "0.2.3",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [UNRELEASED] - YYYY-MM-DD
+
 ## [0.3.2] - 2022-04-02
 
 - Update to rtl_433 master as of Mar 26, 2022 #82

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [UNRELEASED] - YYYY-MM-DD
+## [0.3.3] - 2022-05-09
+
+- Update to rtl_433 master as of April 28, 2022
 
 ## [0.3.2] - 2022-04-02
 

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=homeassistant/amd64-base-python:3.9-alpine3.13
 FROM ${BUILD_FROM} as builder
 
-ARG rtl433GitRevision=778b94ca984c9792a5f5d5bee8910de6bd473b26
+ARG rtl433GitRevision=9eec461132ee880c4e1a969026f81be9934682cf
 
 # Copy files from root folder
 COPY 1665.diff \

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433 MQTT Auto Discovery",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch}",
-  "version": "next",
+  "version": "0.3.3",
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery",

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433 MQTT Auto Discovery",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch}",
-  "version": "0.3.2",
+  "version": "next",
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery",


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

Resolves #87.