### PR TITLE
Fix output lag due to sed buffering #85

### DIFF
--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -33,7 +33,8 @@ FROM $BUILD_FROM
 ENV LANG C.UTF-8
 
 RUN apk add --no-cache libusb \
-    librtlsdr
+    librtlsdr \
+    sed
 WORKDIR /root
 COPY --from=builder /build/root/ /
 

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -70,7 +70,7 @@ do
 
     echo "Starting rtl_433 with $live..."
     tag=$(basename $live .conf)
-    rtl_433 -c "$live" > >(sed "s/^/[$tag] /") 2> >(>&2 sed "s/^/[$tag] /")&
+    rtl_433 -c "$live" > >(sed -u "s/^/[$tag] /") 2> >(>&2 sed -u "s/^/[$tag] /")&
     rtl_433_pids+=($!)
 done
 


### PR DESCRIPTION
## Summary

Fixes #85 .

## Alternatives Considered

There are other ways to force unbuffered output, but this is by far the clearest to future maintainers.

## Testing Steps

1. Enable `output kv`
2. Run the addon or docker container.
3. There shouldn't be any obvious lag log output.