### PR TITLE
Ensure template has an EOL character when rendering #81

### DIFF
--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -64,6 +64,11 @@ do
     # we wrap the needed redirections into a temparary file.
     echo "cat <<EOD > $live" > /tmp/rtl_433_heredoc
     cat $template >> /tmp/rtl_433_heredoc
+
+    # Ensure a newline exists in case the template doesn't have one at the end
+    # of its file.
+    echo >> /tmp/rtl_433_heredoc
+
     echo EOD >> /tmp/rtl_433_heredoc
 
     source /tmp/rtl_433_heredoc


### PR DESCRIPTION
## Summary

Fixes #81 .

## Alternatives Considered

We could use sed for this as well, but that seems more complicated. There's no harm in an extra blank line for the case where the file contains it like normal.

## Testing Steps

1. Remove the trailing newline from a configuration file: https://stackoverflow.com/questions/1050640/how-to-stop-vim-from-adding-a-newline-at-end-of-file
2. Run the addon with the config file.
3. It should work instead of erroring out parsing the configuration.