### PR TITLE
Upgrade rtl 433 to the latest master #117

### DIFF
--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache --virtual .buildDeps \
     git
 
 WORKDIR /build
-ARG rtl433GitRevision=e066b669f7574c37f943f251ec8023b00cff1df6
+ARG rtl433GitRevision=5f76eae6f6bf9c696b859296301bbbe234de77fe
 RUN git clone https://github.com/merbanan/rtl_433
 WORKDIR ./rtl_433
 

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=homeassistant/amd64-base-python:3.9-alpine3.16
 FROM ${BUILD_FROM} as builder
 
-ARG rtl433GitRevision=e066b669f7574c37f943f251ec8023b00cff1df6
+ARG rtl433GitRevision=5f76eae6f6bf9c696b859296301bbbe234de77fe
 
 # Copy files from root folder
 COPY 1665.diff \


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

We'd like the fix for rain meters mentioned at https://github.com/pbkhrv/rtl_433-hass-addons/issues/117.

## Alternatives Considered

We could never upgrade and be sad.

## Testing Steps

1. Builds complete.
2. Pull the `#-merge` tag for this PR and overwrite the local tag, and restart.