### PR TITLE
Update patch for Update mqtt hass to include triggers #2102

### DIFF
--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
 
-* Upgrade rtl 433 to the latest master #117 #119
+* Upgrade rtl_433 to the latest master #117 #119
 
 ## [0.3.0] - 2022-10-19
 

--- a/rtl_433_mqtt_autodiscovery/2102.diff
+++ b/rtl_433_mqtt_autodiscovery/2102.diff
@@ -1,8 +1,8 @@
 diff --git a/examples/rtl_433_mqtt_hass.py b/examples/rtl_433_mqtt_hass.py
-index 706d9437..bccf3ebf 100755
+index 8b8136f96..6baa5197a 100755
 --- a/examples/rtl_433_mqtt_hass.py
 +++ b/examples/rtl_433_mqtt_hass.py
-@@ -111,7 +111,7 @@ NAMING_KEYS = [ "type", "model", "subtype", "channel", "id" ]
+@@ -105,7 +105,7 @@
  
  # Fields that get ignored when publishing to Home Assistant
  # (reduces noise to help spot missing field mappings)
@@ -11,24 +11,37 @@ index 706d9437..bccf3ebf 100755
                              "message_type", "exception", "raw_msg" ]
  
  
-@@ -164,7 +164,15 @@ mappings = {
-             "state_class": "measurement"
+@@ -159,12 +159,29 @@
          }
      },
--
+ 
++    # This diagnostic sensor is useful to see when a device last sent a value,
++    # even if the value didn't change.
++    # https://community.home-assistant.io/t/send-metrics-to-influxdb-at-regular-intervals/9096
++    # https://github.com/home-assistant/frontend/discussions/13687
 +    "time": {
 +        "device_type": "sensor",
 +        "object_suffix": "UTC",
 +        "config": {
 +            "device_class": "timestamp",
 +            "name": "Timestamp",
++            "entity_category": "diagnostic",
++            "enabled_by_default": False,
 +            "icon": "mdi:clock-in"
 +        }
 +    },
++
      "battery_ok": {
          "device_type": "sensor",
          "object_suffix": "B",
-@@ -537,6 +545,61 @@ mappings = {
+         "config": {
+             "device_class": "battery",
+             "name": "Battery",
++            "entity_category": "diagnostic",
+             "unit_of_measurement": "%",
+             "value_template": "{{ float(value) * 99 + 1 }}",
+             "state_class": "measurement",
+@@ -541,8 +558,56 @@
          }
      },
  
@@ -41,6 +54,7 @@ index 706d9437..bccf3ebf 100755
 +           "subtype": "button_1",
 +        }
 +    },
++
 +    "button": {
 +        "device_type": "device_automation",
 +        "object_suffix": "BTN",
@@ -50,57 +64,50 @@ index 706d9437..bccf3ebf 100755
 +           "subtype": "button_1",
 +        }
 +    },
-+    "code": {
-+        "device_type": "device_automation",
-+        "object_suffix": "CODE",
-+        "config": {
-+           "automation_type": "trigger",
-+           "type": "button_short_release",
-+           "subtype": "button_1",
-+        }
-+    },
-+    "unit": {
-+        "device_type": "device_automation",
-+        "object_suffix": "unit",
-+        "config": {
-+           "automation_type": "trigger",
-+           "type": "button_short_release",
-+           "subtype": "button_1",
-+        }
-+    },
-+    "tristate": {
-+        "device_type": "device_automation",
-+        "object_suffix": "tristate",
-+        "config": {
-+           "automation_type": "trigger",
-+           "type": "button_short_release",
-+           "subtype": "button_1",
-+        }
-+    },
-+    "cmd": {
-+        "device_type": "device_automation",
-+        "object_suffix": "CMD",
-+        "config": {
-+           "automation_type": "trigger",
-+           "type": "button_short_release",
-+           "subtype": "button_1",
-+        }
-+    },
 +
  }
  
++# Use secret_knock to trigger device automations for Honeywell ActivLink
++# doorbells. We have this outside of mappings as we need to configure two
++# different configuration topics.
++secret_knock_mappings = [
++
++    {
++        "device_type": "device_automation",
++        "object_suffix": "Knock",
++        "config": {
++            "automation_type": "trigger",
++            "type": "button_short_release",
++            "subtype": "button_1",
++            "payload": 0,
++        }
++    },
++
++    {
++        "device_type": "device_automation",
++        "object_suffix": "Secret-Knock",
++        "config": {
++            "automation_type": "trigger",
++            "type": "button_triple_press",
++            "subtype": "button_1",
++            "payload": 1,
++        }
++    },
++
++]
  
-@@ -592,8 +655,7 @@ def rtl_433_device_topic(data):
- 
+ def mqtt_connect(client, userdata, flags, rc):
+     """Callback for MQTT connects."""
+@@ -597,7 +662,7 @@ def rtl_433_device_topic(data):
      return '/'.join(path_elements)
  
--
+ 
 -def publish_config(mqttc, topic, model, instance, mapping):
 +def publish_config(mqttc, topic, model, instance, mapping, value=None):
      """Publish Home Assistant auto discovery data."""
      global discovery_timeouts
  
-@@ -615,10 +677,16 @@ def publish_config(mqttc, topic, model, instance, mapping):
+@@ -619,10 +684,18 @@ def publish_config(mqttc, topic, model, instance, mapping):
      discovery_timeouts[path] = now + args.discovery_interval
  
      config = mapping["config"].copy()
@@ -109,10 +116,12 @@ index 706d9437..bccf3ebf 100755
 -    config["unique_id"] = object_name
 -    config["device"] = { "identifiers": object_id, "name": object_id, "model": model, "manufacturer": "rtl_433" }
 +
++    # Device Automation configuration is in a different structure compared to
++    # all other mqtt discovery types.
++    # https://www.home-assistant.io/integrations/device_trigger.mqtt/
 +    if device_type == 'device_automation':
 +        config["topic"] = topic
 +        config["platform"] = 'mqtt'
-+        config["payload"] = value
 +    else:
 +        config["state_topic"] = topic
 +        config["unique_id"] = object_name
@@ -121,3 +130,16 @@ index 706d9437..bccf3ebf 100755
  
      if args.force_update:
          config["force_update"] = "true"
+@@ -671,6 +744,12 @@ def bridge_event_to_hass(mqttc, topicprefix, data):
+             if key not in SKIP_KEYS:
+                 skipped_keys.append(key)
+ 
++    if "secret_knock" in data.keys():
++        for m in secret_knock_mappings:
++            topic = "/".join([topicprefix,"devices",instance,"secret_knock"])
++            if publish_config(mqttc, topic, model, instance, m):
++                published_keys.append("secret_knock")
++
+     if published_keys:
+         logging.info("Published %s: %s" % (instance, ", ".join(published_keys)))
+ 

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [UNRELEASED] - YYYY-MM-DD
 
-* Upgrade rtl 433 to the latest master #117 #119
+* Upgrade rtl_433 to the latest master #117 #119
+* Update patch for "Update mqtt hass to include triggers #2102"
+  * `time` and `battery_ok` sensors are now set as diagnostic sensors in Home Assistant.
+  * `time` sensors are disabled by default.
+  * `channel` and `button` sensors trigger button device automations.
+  * Honeywell Doorbells now support triggering knocks (1 push) and secret knocks (3 pushes) as device automations.
 
 ## [0.4.0] - 2022-10-19
 

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -4,14 +4,14 @@ FROM ${BUILD_FROM} as builder
 ARG rtl433GitRevision=e066b669f7574c37f943f251ec8023b00cff1df6
 
 # Copy files from root folder
-COPY 1665.diff \
+COPY 2102.diff \
      /
 
 RUN apk add patch
 RUN wget https://raw.githubusercontent.com/merbanan/rtl_433/${rtl433GitRevision}/examples/rtl_433_mqtt_hass.py -O rtl_433_mqtt_hass.py
 
-# https://github.com/merbanan/rtl_433/pull/1665#issuecomment-1034188020
-RUN patch -u rtl_433_mqtt_hass.py 1665.diff
+# https://github.com/merbanan/rtl_433/pull/2102
+RUN patch -u rtl_433_mqtt_hass.py 2102.diff
 
 FROM ${BUILD_FROM}
 


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

This pulls in https://github.com/merbanan/rtl_433/pull/2102 based on feedback from upstream as well as adding support for Honeywell Doorbell secret knocks.

## Testing Steps

1. Pull `120-merge` from GCR when built and override the tag locally.
2. Verify that device discovery works.