### PR TITLE
run.sh: Use ISO timestamp with timezone and usec precision

### DIFF
--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -42,6 +42,7 @@ then
 # https://github.com/merbanan/rtl_433/blob/master/conf/rtl_433.example.conf
 
 output mqtt://\${host}:\${port},user=\${username},pass=\${password},retain=\${retain}
+report_meta time:iso:usec:tz
 
 # Uncomment the following line to also enable the default "table" output to the
 # addon logs.


### PR DESCRIPTION
This is what HA expects to receive otherwise it would fail with:

  ValueError: Invalid datetime: sensor.bresser_5_in_1_utc provides
  state '2022-12-31 05:33:33', which is missing timezone information

See: https://github.com/merbanan/rtl_433/issues/2293