### PR TITLE
Add example for preserving topic structure between versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,7 @@ on:
   schedule:
     # A random daily time, as Actions doesn't have a suggestion for running
     # daily without causing job spikes.
-    # - cron:  '16 8 * * *'
-    # Set to a short time for testing.
-    - cron:  '16 * * * *'
+    - cron:  '16 8 * * *'
 
 env:
   REGISTRY: ghcr.io

--- a/rtl_433-next/README.md
+++ b/rtl_433-next/README.md
@@ -6,4 +6,17 @@ This is the "next" version of the rtl_433 addon for Home Assistant. It includes
 both unreleased changes to the addon itself, and whatever the latest
 code from the rtl_433 master branch is available at build time.
 
-To update, uninstall and reinstall the addon.
+When starting, rtl_433 will show the version info such as:
+
+```
+[rtl_433] rtl_433 version 22.11-89-g416d6c4f branch master at 202302071819 inputs file rtl_tcp RTL-SDR
+```
+
+To keep the same topics in MQTT when switching between the normal and next
+versions of the addon, change the `output` lines in each configuration file to:
+
+```
+output mqtt://${host}:${port},user=${username},pass=${password},retain=${retain},devices=rtl_433/9b13b3f4-rtl433/devices[/type][/model][/subtype][/channel][/id],events=rtl_433/9b13b3f4-rtl433/events,states=rtl_433/9b13b3f4-rtl433/states
+```
+
+To update rtl_433 to the latest version, uninstall and reinstall the addon.

--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.4.0] - 2023-02-08
+
+* Update rtl_433 to the 22.11 release.
+* Adds a new "next" version of the addon that tracks our next branch and rtl_433 master.
+  * The addon is built once per day. To update, the "next" addon must be uninstalled and reinstalled.
+  * The output line in each configuration file likely needs to be updated to preserve existing topic layouts.
+
 ## [0.3.1] - 2022-10-25
 
 * Upgrade rtl_433 to the latest master #117 #119

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -43,6 +43,10 @@ then
 
 output mqtt://\${host}:\${port},user=\${username},pass=\${password},retain=\${retain}
 
+# To keep the same topics when switching between the normal and edge versions,
+# use this output line instead.
+# output mqtt://\${host}:\${port},user=\${username},pass=\${password},retain=\${retain},devices=rtl_433/9b13b3f4-rtl433/devices[/type][/model][/subtype][/channel][/id],events=rtl_433/9b13b3f4-rtl433/events,states=rtl_433/9b13b3f4-rtl433/states
+
 # Uncomment the following line to also enable the default "table" output to the
 # addon logs.
 # output kv

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.6.0] - 2023-02-08
+
+* Update rtl_433 to the 22.11 release.
+
 ## [0.5.0] - 2022-10-25
 
 * Upgrade rtl_433 to the latest master #117 #119


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

rtl_433 uses the hostname when calculating default topics. When switching between the normal and next versions, the hostname changes. That makes it difficult to switch back and forth since all of the devices will be in a different tree.

This PR adds an example and updates the README of the next addon.

## Alternatives Considered

I thought about simply hardcoding the topic always, but I think that adds an extra layer of confusion to the configuration that most users won't benefit from.

## Testing Steps

1.  Pull this build down, or build locally.
2. Add or uncomment the output line added in this PR in the configuration file.
3. Stop the regular addon, and install the next addon.
4. Messages should be published to the same existing topics.