### PR TITLE
Prepare for 0.4.0 / 0.6.0 release

### DIFF
--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Adds a new "next" version of the addon that tracks our next branch and rtl_433 master.
   * The addon is built once per day. To update, the "next" addon must be uninstalled and reinstalled.
   * The output line in each configuration file likely needs to be updated to preserve existing topic layouts.
+* run.sh: Use ISO timestamp with timezone and usec precision #128
 
 ## [0.3.1] - 2022-10-25
 

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-{arch}",
-  "version": "next",
+  "version": "0.4.0",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433 MQTT Auto Discovery",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch}",
-  "version": "next",
+  "version": "0.6.0",
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery",


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

New release of the addons!