### PR TITLE
[docs] Include architecture name for Raspberry Pi

### DIFF
--- a/rtl_433_mqtt_autodiscovery/README.md
+++ b/rtl_433_mqtt_autodiscovery/README.md
@@ -123,7 +123,7 @@ version: '3'
 services:
   rtl_433_autodiscovery:
     container_name: rtl_433_autodiscovery
-    image: ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-amd64 # On Raspberry Pi use: rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-armhf
+    image: ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-amd64 # On Raspberry Pi replace `amd64` with the appropriate architecture.
     environment:
       - MQTT_HOST=mqtt.example.com
       - MQTT_USERNAME=username

--- a/rtl_433_mqtt_autodiscovery/README.md
+++ b/rtl_433_mqtt_autodiscovery/README.md
@@ -114,7 +114,7 @@ Follow these steps to run just the autodiscovery script in a dedicated container
 docker run -e MQTT_HOST=mqtt.example.com -e MQTT_USERNAME=username -e MQTT_PASSWORD=password ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-amd64
 ```
 
-Replace `amd64` with your appropriate architecture. For Raspberry Pi, this is `armhf`.
+Replace `amd64` with your appropriate architecture. For Raspberry Pi, this is `armhf`, `armv7`, or `aarch64` depending on your Pi version and operating system. If unsure, running `arch` at the command line can help identify the architecture.
 
 Using docker-compose:
 

--- a/rtl_433_mqtt_autodiscovery/README.md
+++ b/rtl_433_mqtt_autodiscovery/README.md
@@ -114,7 +114,7 @@ Follow these steps to run just the autodiscovery script in a dedicated container
 docker run -e MQTT_HOST=mqtt.example.com -e MQTT_USERNAME=username -e MQTT_PASSWORD=password ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-amd64
 ```
 
-Replace `amd64` with your appropriate architecture.
+Replace `amd64` with your appropriate architecture. For Raspberry Pi, this is `armhf`.
 
 Using docker-compose:
 
@@ -123,7 +123,7 @@ version: '3'
 services:
   rtl_433_autodiscovery:
     container_name: rtl_433_autodiscovery
-    image: ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-amd64
+    image: ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-amd64 # On Raspberry Pi use: rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-armhf
     environment:
       - MQTT_HOST=mqtt.example.com
       - MQTT_USERNAME=username


### PR DESCRIPTION
Include architecture name for Raspberry Pi

<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

<!-- Write a summary of what you're trying to solve, with links to any relevant
     issues, and how this PR solves it.
     -->

## Alternatives Considered

<!-- Are there other ways to add the feature or solve the bug you considered?
     Why didn't you pursue them further?
     -->

## Testing Steps

1. First...
2. Then...
3. You should see... (screenshots or console text are helpful)