### PR TITLE
Fix port number is missing sometimes

### DIFF
--- a/rtl_433_mqtt_autodiscovery/run.sh
+++ b/rtl_433_mqtt_autodiscovery/run.sh
@@ -51,5 +51,9 @@ else
   fi
 fi
 
+if [ ! -z ${MQTT_PORT+x} ]; then
+  MQTT_PORT="1883"
+fi
+
 echo "Starting rtl_433_mqtt_hass.py..."
 python3 -u /rtl_433_mqtt_hass.py -H $MQTT_HOST -p $MQTT_PORT -R "$RTL_TOPIC" -D "$DISCOVERY_PREFIX" -i $DISCOVERY_INTERVAL $OTHER_ARGS

--- a/rtl_433_mqtt_autodiscovery/run.sh
+++ b/rtl_433_mqtt_autodiscovery/run.sh
@@ -51,6 +51,7 @@ else
   fi
 fi
 
+# Set a default port for when the container is being run directly.
 if [ ! -z ${MQTT_PORT+x} ]; then
   MQTT_PORT="1883"
 fi


### PR DESCRIPTION
Happens with default Docker config. Fixes #141.

<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

<!-- Write a summary of what you're trying to solve, with links to any relevant
     issues, and how this PR solves it.
     -->

## Alternatives Considered

<!-- Are there other ways to add the feature or solve the bug you considered?
     Why didn't you pursue them further?
     -->

## Testing Steps

1. First...
2. Then...
3. You should see... (screenshots or console text are helpful)