### PR TITLE
Fix wrong retain value when setting in mqtt connection string

### DIFF
--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased] - YYYY-MM-DD
+
+* Fix wrong retain value when setting in mqtt connection string #149 by @cserem
+
 ## [0.4.0] - 2023-02-08
 
 * Update rtl_433 to the 22.11 release.

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -8,6 +8,9 @@ if bashio::services.available "mqtt"; then
     port=$(bashio::services "mqtt" "port")
     username=$(bashio::services "mqtt" "username")
     retain=$(bashio::config "retain")
+    if [ "$retain" = "true" ] ; then
+       retain=1
+    fi 
 else
     bashio::log.info "The mqtt addon is not available."
     bashio::log.info "Manually update the output line in the configuration file with mqtt connection settings, and restart the addon."


### PR DESCRIPTION
rtl433 expects numbers instead of true/false for retain flag. Don't know if this is the proper way to fix it, but it seems to work for me.
