### PR TITLE
Use git build

### DIFF
--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -3,11 +3,16 @@ FROM ${BUILD_FROM} as builder
 
 ARG rtl433GitRevision=22.11
 
-RUN wget https://github.com/merbanan/rtl_433/raw/${rtl433GitRevision}/examples/rtl_433_mqtt_hass.py?$RANDOM -O rtl_433_mqtt_hass.py
+RUN apk add --no-cache --virtual .buildDeps \
+    git
+
+RUN git clone https://github.com/merbanan/rtl_433
+WORKDIR rtl_433
+RUN git checkout ${rtl433GitRevision}
 
 FROM ${BUILD_FROM}
 
-COPY --from=builder rtl_433_mqtt_hass.py .
+COPY --from=builder /rtl_433/examples/rtl_433_mqtt_hass.py .
 COPY run.sh .
 
 RUN \


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

While I expect by now caches have cleared, this will fully prevent the issue I mentioned at https://github.com/pbkhrv/rtl_433-hass-addons/pull/144#issuecomment-1687311954 from happening.

## Alternatives Considered

I actually tried query busters and other usual tricks and they didn't work. This seems simplest and repeatable.

## Testing Steps

1. Let this build!
2. Fetch and confirm that the md5 of the script is `15e12918b95e45e82de71273094b1a9f`.