### PR TITLE
set the correct URL for the next autodiscovery image

### DIFF
--- a/rtl_433_mqtt_autodiscovery-next/config.json
+++ b/rtl_433_mqtt_autodiscovery-next/config.json
@@ -1,6 +1,6 @@
 {
   "name": "rtl_433 MQTT Auto Discovery (next)",
-  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch}",
+  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-next-{arch}",
   "version": "next",
   "slug": "rtl433mqttautodiscovery-next",
   "description": "Automatic discovery of rtl_433 device information via MQTT",


### PR DESCRIPTION
<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

<!-- Write a summary of what you're trying to solve, with links to any relevant
     issues, and how this PR solves it.
     -->

The path to the 'next' version of the rtl_433_mqtt_autodiscovery add-on is incorrect, and so when trying to install home assistant actually installs a copy of the main / release version instead. The path should contain 'next-' from what I can tell based on the container names.

## Alternatives Considered

I've created my own copy of the repo to work on another feature, and discovered this in the meantime. I can use my own copy of the image there only by making this change.

## Testing Steps

1. forked the repo
2. changed all the paths / actions / repo names to point to my copies of  these things
3. disabled building of the non-next versions of the images
4. Built the images
5. was not able to install (home assistant gave an error about the image not being available)
6. Applied this fix
7. was able to install