### PR TITLE
Update stable release of rtl_433

### DIFF
--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED] - YYYY-MM-DD
+
+* Update to rtl_433 23.11 for the stable addon
+
 ## [0.4.1] - 2023-10-27
 
 * Fix wrong retain value when setting in mqtt connection string #149 by @cserem

--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -18,7 +18,7 @@ RUN git clone https://github.com/merbanan/rtl_433
 WORKDIR ./rtl_433
 
 # Build a specific commit or tag.
-ARG rtl433GitRevision=22.11
+ARG rtl433GitRevision=23.11
 RUN git checkout ${rtl433GitRevision}
 WORKDIR ./build
 RUN cmake ..

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED] - YYYY-MM-DD
+
+* Update to rtl_433 23.11 for the stable addon
+
 ## [0.7.0] - 2023-10-27
 
 * `device_topic_suffix` support added by @unverbraucht #144

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.18
 FROM ${BUILD_FROM} as builder
 
-ARG rtl433GitRevision=22.11
+ARG rtl433GitRevision=23.11
 
 RUN wget https://raw.githubusercontent.com/merbanan/rtl_433/${rtl433GitRevision}/examples/rtl_433_mqtt_hass.py -O rtl_433_mqtt_hass.py
 


### PR DESCRIPTION
## Summary

A new release was made last week. There are some breaking changes but nothing that should affect the addon itself.

https://github.com/merbanan/rtl_433/releases/tag/23.11

## Testing Steps

1. Builds pass
2. `next` should already contain these changes
3. Once builds are complete, it is possible to download and manually overwrite the docker tag to force the stable install of the addon to use the newer version, even before it's released.
