### PR TITLE
Default mqtt_retain to true #88

### DIFF
--- a/rtl_433_mqtt_autodiscovery-next/config.json
+++ b/rtl_433_mqtt_autodiscovery-next/config.json
@@ -15,7 +15,7 @@
     "mqtt_port": 1883,
     "mqtt_user": "",
     "mqtt_password": "",
-    "mqtt_retain": false,
+    "mqtt_retain": true,
     "rtl_topic": "rtl_433/+/events",
     "device_topic_suffix": "",
     "discovery_prefix": "homeassistant",

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNRELEASED] - YYYY-MM-DD
 
 * Update to rtl_433 23.11 for the stable addon
+* Default `retain` to true. The recommended approach to running the addon is to only run discovery when actually trying to add a device.
 
 ## [0.7.0] - 2023-10-27
 

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -14,7 +14,7 @@
     "mqtt_port": 1883,
     "mqtt_user": "",
     "mqtt_password": "",
-    "mqtt_retain": false,
+    "mqtt_retain": true,
     "rtl_topic": "rtl_433/+/events",
     "device_topic_suffix": "",
     "discovery_prefix": "homeassistant",


### PR DESCRIPTION
## Summary

Resolves https://github.com/pbkhrv/rtl_433-hass-addons/issues/88

## Alternatives Considered

The README has documented not running autodiscovery all the time to prevent adding additional low-quality or TPMS sensors, so this just makes that step a bit easier.