### PR TITLE
Downgrade paho-mqtt to 1.x

### DIFF
--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.1] - 2024-02-17
+
+* Add better help text when the mqtt addon isn't in use or available
+
 ## [0.5.0] - 2024-02-16
 
 * Update to rtl_433 23.11 for the stable addon

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-{arch}",
-  "version": "next",
+  "version": "0.5.1",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-{arch}",
-  "version": "0.5.0",
+  "version": "next",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -10,10 +10,12 @@ if bashio::services.available "mqtt"; then
     retain=$(bashio::config "retain")
     if [ "$retain" = "true" ] ; then
        retain=1
-    fi 
+    fi
 else
     bashio::log.info "The mqtt addon is not available."
-    bashio::log.info "Manually update the output line in the configuration file with mqtt connection settings, and restart the addon."
+    bashio::log.info "This is not a problem if you are using an external MQTT broker."
+    bashio::log.info "If you are using the Home Assistant Mosquitto Broker addon, try restarting it, and then restart the rtl_433 addon."
+    bashio::log.info "For an external broker, manually update the output line in the configuration file with mqtt connection settings, and restart the addon."
 fi
 
 if [ ! -d $conf_directory ]

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.8.1] - 2024-02-17
+
+* Downgrade paho-mqtt to 1.6.3 as 2.x has compatibility breaks. #178 #179
+
 ## [0.8.0] - 2024-02-16
 
 * Update to rtl_433 23.11 for the stable addon

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     pip install \
         --no-cache-dir \
         --prefer-binary \
-        paho-mqtt \
+        paho-mqtt==1.6.1 \
     \
     && chmod a+x /run.sh
 

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433 MQTT Auto Discovery",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch}",
-  "version": "next",
+  "version": "0.8.1",
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery",

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -1,7 +1,7 @@
 {
   "name": "rtl_433 MQTT Auto Discovery",
   "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch}",
-  "version": "0.8.0",
+  "version": "next",
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery",


### PR DESCRIPTION
## Summary

paho-mqtt released a new 2.x version last week, and we weren't pinning or specifying a specific version in the docker scripts.

Thanks to the report at https://github.com/fl4p/batmon-ha/issues/197 for confirming this.

I also snuck in some basic help message improvements for when the mqtt addon itself isn't available.

## Alternatives Considered

I'll file an upstream issue since this will break the out-of-the-box experience for the rtl_433 project too.

## Testing Steps

1. Pull `ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-next-{arch}:180-merge` once builds are done.
2. Tag it locally as next or the 0.8.0 release to overwrite it locally.
3. Addon should start.