### PR TITLE
Update base Home Assistant Alpine image to 3.19

### DIFF
--- a/rtl_433-next/build.json
+++ b/rtl_433-next/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base:3.19",
-    "amd64": "homeassistant/amd64-base:3.19",
-    "armhf": "homeassistant/armhf-base:3.19",
-    "armv7": "homeassistant/armv7-base:3.19",
-    "i386": "homeassistant/i386-base:3.19"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.19",
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.19",
+    "armhf": "ghcr.io/home-assistant/armhf-base:3.19",
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.19",
+    "i386": "ghcr.io/home-assistant/i386-base:3.19"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433-next/build.json
+++ b/rtl_433-next/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base:3.18",
-    "amd64": "homeassistant/amd64-base:3.18",
-    "armhf": "homeassistant/armhf-base:3.18",
-    "armv7": "homeassistant/armv7-base:3.18",
-    "i386": "homeassistant/i386-base:3.18"
+    "aarch64": "homeassistant/aarch64-base:3.19",
+    "amd64": "homeassistant/amd64-base:3.19",
+    "armhf": "homeassistant/armhf-base:3.19",
+    "armv7": "homeassistant/armv7-base:3.19",
+    "i386": "homeassistant/i386-base:3.19"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.18
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19
 FROM $BUILD_FROM as builder
 MAINTAINER pbkhrv@pm.me
 

--- a/rtl_433_mqtt_autodiscovery-next/build.json
+++ b/rtl_433_mqtt_autodiscovery-next/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.18",
-    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.18",
-    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.18",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.18",
-    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.18"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.19",
+    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.19",
+    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.19",
+    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.19",
+    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.19"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.18
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.19
 FROM ${BUILD_FROM} as builder
 
 ARG rtl433GitRevision=23.11

--- a/rtl_433_mqtt_autodiscovery/build.json
+++ b/rtl_433_mqtt_autodiscovery/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.18",
-    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.18",
-    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.18",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.18",
-    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.18"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.19",
+    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.19",
+    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.19",
+    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.19",
+    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.19"
   }
 }


### PR DESCRIPTION
Fixes #181

<!-- Thank you for your contribution to this addon! -->

<!-- rtl_433_mqtt_autodiscovery/rtl_433_mqtt_hass.py is maintained upstream at
     merbanan/rtl_433. In general, changes to that file should be filed as a
     pull request there first.
     -->

<!-- Please open normal feature and bug fix requests against the "next" branch.
     This allows us to merge changes without immediately sending the change to
     addon users.
     -->

## Summary

Adds support for RTL-SDR Blog V4 Dongle by upgrading base image, which includes an up to date version (2.0.1) of librtlsdr.

## Alternatives Considered

It would have been possible to fix this more narrowly by upgrading the base image only in rtl_433, or even by just upgrading librtlsdr. However, the base image would need to be upgraded eventually in any case.

## Testing Steps

Applied changes locally by copying updated version of addon to my Home Assistant Green running latest OS via Samba, with image field deleted from config.json to prevent use of pre-built Docker image.