### PR TITLE
Upgrade base images to Alpine 3.21

### DIFF
--- a/rtl_433-next/build.json
+++ b/rtl_433-next/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.19",
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.19",
-    "armhf": "ghcr.io/home-assistant/armhf-base:3.19",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.19",
-    "i386": "ghcr.io/home-assistant/i386-base:3.19"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.21",
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.21",
+    "armhf": "ghcr.io/home-assistant/armhf-base:3.21",
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.21",
+    "i386": "ghcr.io/home-assistant/i386-base:3.21"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED] - YYYY-MM-DD
+
+* Update Alpine base to 3.21
+
 ## [0.5.3] - 2024-10-20
 
 * Support SoapySDR devices #198 #199

--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.21
 FROM $BUILD_FROM as builder
 MAINTAINER pbkhrv@pm.me
 

--- a/rtl_433/build.json
+++ b/rtl_433/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.19",
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.19",
-    "armhf": "ghcr.io/home-assistant/armhf-base:3.19",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.19",
-    "i386": "ghcr.io/home-assistant/i386-base:3.19"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.21",
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.21",
+    "armhf": "ghcr.io/home-assistant/armhf-base:3.21",
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.21",
+    "i386": "ghcr.io/home-assistant/i386-base:3.21"
   }
 }

--- a/rtl_433_mqtt_autodiscovery-next/build.json
+++ b/rtl_433_mqtt_autodiscovery-next/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.19",
-    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.19",
-    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.19",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.19",
-    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.19"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21",
+    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21",
+    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.21",
+    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21",
+    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.21"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED] - YYYY-MM-DD
+
+* Update Alpine base to 3.21
+
 ## [0.8.2] - 2024-06-23
 
 * Upgrade base images to support RTL-SDR V4 #181

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.19
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21
 FROM ${BUILD_FROM} as builder
 
 ARG rtl433GitRevision=23.11

--- a/rtl_433_mqtt_autodiscovery/build.json
+++ b/rtl_433_mqtt_autodiscovery/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.19",
-    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.19",
-    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.19",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.19",
-    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.19"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21",
+    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21",
+    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.21",
+    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21",
+    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.21"
   }
 }


### PR DESCRIPTION
## Summary

Updates our base images from Alpine 3.19 to 3.21.

## Testing Steps

1. Images build!
