### PR TITLE
Remove deprecated architectures (main)

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: [armhf, armv7, aarch64, amd64, i386]
+        arch: [armhf, armv7, aarch64, amd64]
         addon: [rtl_433, rtl_433-next, rtl_433_mqtt_autodiscovery, rtl_433_mqtt_autodiscovery-next]
 
     steps:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: [armv7, aarch64, amd64]
+        arch: [aarch64, amd64]
         addon: [rtl_433, rtl_433-next, rtl_433_mqtt_autodiscovery, rtl_433_mqtt_autodiscovery-next]
 
     steps:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: [armhf, armv7, aarch64, amd64]
+        arch: [armv7, aarch64, amd64]
         addon: [rtl_433, rtl_433-next, rtl_433_mqtt_autodiscovery, rtl_433_mqtt_autodiscovery-next]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: [armhf, armv7, aarch64, amd64]
+        arch: [armv7, aarch64, amd64]
         addon: [rtl_433, rtl_433-next, rtl_433_mqtt_autodiscovery, rtl_433_mqtt_autodiscovery-next]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: [armhf, armv7, aarch64, amd64, i386]
+        arch: [armhf, armv7, aarch64, amd64]
         addon: [rtl_433, rtl_433-next, rtl_433_mqtt_autodiscovery, rtl_433_mqtt_autodiscovery-next]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: [armv7, aarch64, amd64]
+        arch: [aarch64, amd64]
         addon: [rtl_433, rtl_433-next, rtl_433_mqtt_autodiscovery, rtl_433_mqtt_autodiscovery-next]
 
     steps:

--- a/rtl_433-next/build.json
+++ b/rtl_433-next/build.json
@@ -1,8 +1,7 @@
 {
   "build_from": {
     "aarch64": "ghcr.io/home-assistant/aarch64-base:3.21",
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.21",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.21"
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.21"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433-next/build.json
+++ b/rtl_433-next/build.json
@@ -3,8 +3,7 @@
     "aarch64": "ghcr.io/home-assistant/aarch64-base:3.21",
     "amd64": "ghcr.io/home-assistant/amd64-base:3.21",
     "armhf": "ghcr.io/home-assistant/armhf-base:3.21",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.21",
-    "i386": "ghcr.io/home-assistant/i386-base:3.21"
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.21"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433-next/build.json
+++ b/rtl_433-next/build.json
@@ -2,7 +2,6 @@
   "build_from": {
     "aarch64": "ghcr.io/home-assistant/aarch64-base:3.21",
     "amd64": "ghcr.io/home-assistant/amd64-base:3.21",
-    "armhf": "ghcr.io/home-assistant/armhf-base:3.21",
     "armv7": "ghcr.io/home-assistant/armv7-base:3.21"
   },
   "args": {

--- a/rtl_433-next/config.json
+++ b/rtl_433-next/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433-next",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433-next",
-  "arch": ["armhf", "armv7", "aarch64", "amd64"],
+  "arch": ["armv7", "aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433-next/config.json
+++ b/rtl_433-next/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433-next",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433-next",
-  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "arch": ["armhf", "armv7", "aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433-next/config.json
+++ b/rtl_433-next/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433-next",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433-next",
-  "arch": ["armv7", "aarch64", "amd64"],
+  "arch": ["aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [UNRELEASED] - YYYY-MM-DD
+
+* Fix unbounded $1 in HEREDOC #230
+* Drop support for architectures Home Assistant has dropped
+
 ## [0.6.0] - 2025-03-22
 
 * Update Alpine base to 3.21

--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## [UNRELEASED] - YYYY-MM-DD
 
-* Fix unbounded $1 in HEREDOC #230
 * Drop support for architectures Home Assistant has dropped
 
 ## [0.6.0] - 2025-03-22

--- a/rtl_433/build.json
+++ b/rtl_433/build.json
@@ -2,7 +2,6 @@
   "build_from": {
     "aarch64": "ghcr.io/home-assistant/aarch64-base:3.21",
     "amd64": "ghcr.io/home-assistant/amd64-base:3.21",
-    "armhf": "ghcr.io/home-assistant/armhf-base:3.21",
     "armv7": "ghcr.io/home-assistant/armv7-base:3.21"
   }
 }

--- a/rtl_433/build.json
+++ b/rtl_433/build.json
@@ -3,7 +3,6 @@
     "aarch64": "ghcr.io/home-assistant/aarch64-base:3.21",
     "amd64": "ghcr.io/home-assistant/amd64-base:3.21",
     "armhf": "ghcr.io/home-assistant/armhf-base:3.21",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.21",
-    "i386": "ghcr.io/home-assistant/i386-base:3.21"
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.21"
   }
 }

--- a/rtl_433/build.json
+++ b/rtl_433/build.json
@@ -1,7 +1,6 @@
 {
   "build_from": {
     "aarch64": "ghcr.io/home-assistant/aarch64-base:3.21",
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.21",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.21"
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.21"
   }
 }

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",
-  "arch": ["armhf", "armv7", "aarch64", "amd64"],
+  "arch": ["armv7", "aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",
-  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "arch": ["armhf", "armv7", "aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433",
-  "arch": ["armv7", "aarch64", "amd64"],
+  "arch": ["aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433_mqtt_autodiscovery-next/build.json
+++ b/rtl_433_mqtt_autodiscovery-next/build.json
@@ -2,7 +2,6 @@
   "build_from": {
     "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21",
     "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21",
-    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.21",
     "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21"
   },
   "args": {

--- a/rtl_433_mqtt_autodiscovery-next/build.json
+++ b/rtl_433_mqtt_autodiscovery-next/build.json
@@ -1,8 +1,7 @@
 {
   "build_from": {
     "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21",
-    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21"
+    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433_mqtt_autodiscovery-next/build.json
+++ b/rtl_433_mqtt_autodiscovery-next/build.json
@@ -3,8 +3,7 @@
     "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21",
     "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21",
     "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.21",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21",
-    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.21"
+    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21"
   },
   "args": {
     "rtl433GitRevision": "master"

--- a/rtl_433_mqtt_autodiscovery-next/config.json
+++ b/rtl_433_mqtt_autodiscovery-next/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433mqttautodiscovery-next",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery-next",
-  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "arch": ["armhf", "armv7", "aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433_mqtt_autodiscovery-next/config.json
+++ b/rtl_433_mqtt_autodiscovery-next/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433mqttautodiscovery-next",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery-next",
-  "arch": ["armv7", "aarch64", "amd64"],
+  "arch": ["aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433_mqtt_autodiscovery-next/config.json
+++ b/rtl_433_mqtt_autodiscovery-next/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433mqttautodiscovery-next",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery-next",
-  "arch": ["armhf", "armv7", "aarch64", "amd64"],
+  "arch": ["armv7", "aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433_mqtt_autodiscovery/CHANGELOG.md
+++ b/rtl_433_mqtt_autodiscovery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED] - YYYY-MM-DD
+
+* Drop support for architectures Home Assistant has dropped
+
 ## [0.9.0] - 2025-03-22
 
 * Update Alpine base to 3.21

--- a/rtl_433_mqtt_autodiscovery/build.json
+++ b/rtl_433_mqtt_autodiscovery/build.json
@@ -3,7 +3,6 @@
     "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21",
     "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21",
     "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.21",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21",
-    "i386": "ghcr.io/home-assistant/i386-base-python:3.12-alpine3.21"
+    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21"
   }
 }

--- a/rtl_433_mqtt_autodiscovery/build.json
+++ b/rtl_433_mqtt_autodiscovery/build.json
@@ -1,7 +1,6 @@
 {
   "build_from": {
     "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21",
-    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21"
+    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21"
   }
 }

--- a/rtl_433_mqtt_autodiscovery/build.json
+++ b/rtl_433_mqtt_autodiscovery/build.json
@@ -2,7 +2,6 @@
   "build_from": {
     "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21",
     "amd64": "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21",
-    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.21",
     "armv7": "ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.21"
   }
 }

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery",
-  "arch": ["armhf", "armv7", "aarch64", "amd64"],
+  "arch": ["armv7", "aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery",
-  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "arch": ["armhf", "armv7", "aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -5,7 +5,7 @@
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",
   "url": "https://github.com/pbkhrv/rtl_433-hass-addons/tree/main/rtl_433_mqtt_autodiscovery",
-  "arch": ["armv7", "aarch64", "amd64"],
+  "arch": ["aarch64", "amd64"],
   "startup": "application",
   "boot": "auto",
   "init": false,


### PR DESCRIPTION
This needs to be on `main` for the scheduled jobs to work, as those only work on the default branch.